### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/101/911/109/101911109.geojson
+++ b/data/101/911/109/101911109.geojson
@@ -154,6 +154,9 @@
         "qs_pg:id":1292120
     },
     "wof:country":"BA",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7fa4d30a478e5ad8e9766784d9dff1a4",
     "wof:hierarchy":[
         {
@@ -165,7 +168,7 @@
         }
     ],
     "wof:id":101911109,
-    "wof:lastmodified":1566605293,
+    "wof:lastmodified":1582321468,
     "wof:name":"Li\u00b5tica",
     "wof:parent_id":1108759231,
     "wof:placetype":"locality",

--- a/data/856/322/67/85632267.geojson
+++ b/data/856/322/67/85632267.geojson
@@ -134,6 +134,9 @@
         "qs_pg:id":224784
     },
     "wof:country":"BA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"860dd104615d780549755e1a741d7e70",
     "wof:hierarchy":[
         {
@@ -153,7 +156,7 @@
         "srp",
         "hrv"
     ],
-    "wof:lastmodified":1566604468,
+    "wof:lastmodified":1582321450,
     "wof:name":"Republic of Srpska",
     "wof:parent_id":85632609,
     "wof:placetype":"region",

--- a/data/856/322/79/85632279.geojson
+++ b/data/856/322/79/85632279.geojson
@@ -372,6 +372,9 @@
         "wd:id":"Q194483"
     },
     "wof:country":"BA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"273f3d0e744b2a09c9b9a4896f60479f",
     "wof:hierarchy":[
         {
@@ -391,7 +394,7 @@
         "srp",
         "hrv"
     ],
-    "wof:lastmodified":1566604469,
+    "wof:lastmodified":1582321450,
     "wof:name":"Brcko Distrikt",
     "wof:parent_id":85632609,
     "wof:placetype":"region",

--- a/data/856/326/09/85632609.geojson
+++ b/data/856/326/09/85632609.geojson
@@ -1228,6 +1228,12 @@
     },
     "wof:country":"BA",
     "wof:country_alpha3":"BIH",
+    "wof:geom_alt":[
+        "naturalearth",
+        "meso",
+        "naturalearth-display-terrestrial-zoom6",
+        "quattroshapes"
+    ],
     "wof:geomhash":"4f9723e3017734422406623471b1ce34",
     "wof:hierarchy":[
         {
@@ -1246,7 +1252,7 @@
         "srp",
         "hrv"
     ],
-    "wof:lastmodified":1566604470,
+    "wof:lastmodified":1582321450,
     "wof:name":"Bosnia and Herzegovina",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/856/692/03/85669203.geojson
+++ b/data/856/692/03/85669203.geojson
@@ -223,6 +223,9 @@
         "wk:page":"Canton 10"
     },
     "wof:country":"BA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"71998f5311f723050c56106256649ef4",
     "wof:hierarchy":[
         {
@@ -242,7 +245,7 @@
         "srp",
         "hrv"
     ],
-    "wof:lastmodified":1566604464,
+    "wof:lastmodified":1582321448,
     "wof:name":"West Bosnia",
     "wof:parent_id":85632609,
     "wof:placetype":"region",

--- a/data/856/692/07/85669207.geojson
+++ b/data/856/692/07/85669207.geojson
@@ -313,6 +313,9 @@
         "wk:page":"Una-Sana Canton"
     },
     "wof:country":"BA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"db2c0c25203fcb923e7186098ccec4a7",
     "wof:hierarchy":[
         {
@@ -332,7 +335,7 @@
         "srp",
         "hrv"
     ],
-    "wof:lastmodified":1566604465,
+    "wof:lastmodified":1582321449,
     "wof:name":"Una-Sana",
     "wof:parent_id":85632609,
     "wof:placetype":"region",

--- a/data/856/692/13/85669213.geojson
+++ b/data/856/692/13/85669213.geojson
@@ -326,6 +326,9 @@
         "wd:id":"Q18262"
     },
     "wof:country":"BA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f88e2d9184957d5ddb2e3893016f0e55",
     "wof:hierarchy":[
         {
@@ -345,7 +348,7 @@
         "srp",
         "hrv"
     ],
-    "wof:lastmodified":1566604467,
+    "wof:lastmodified":1582321449,
     "wof:name":"Central Bosnia",
     "wof:parent_id":85632609,
     "wof:placetype":"region",

--- a/data/856/692/17/85669217.geojson
+++ b/data/856/692/17/85669217.geojson
@@ -309,6 +309,9 @@
         "wk:page":"West Herzegovina Canton"
     },
     "wof:country":"BA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f0635ef85e6fa4a18ed386d64f2c9a0e",
     "wof:hierarchy":[
         {
@@ -328,7 +331,7 @@
         "srp",
         "hrv"
     ],
-    "wof:lastmodified":1566604464,
+    "wof:lastmodified":1582321448,
     "wof:name":"West Herzegovina",
     "wof:parent_id":85632609,
     "wof:placetype":"region",

--- a/data/856/692/21/85669221.geojson
+++ b/data/856/692/21/85669221.geojson
@@ -319,6 +319,9 @@
         "wk:page":"Herzegovina-Neretva Canton"
     },
     "wof:country":"BA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2e3115938cd9f1573de87a472bc1aa38",
     "wof:hierarchy":[
         {
@@ -338,7 +341,7 @@
         "srp",
         "hrv"
     ],
-    "wof:lastmodified":1566604465,
+    "wof:lastmodified":1582321448,
     "wof:name":"Herzegovina-Neretva",
     "wof:parent_id":85632609,
     "wof:placetype":"region",

--- a/data/856/692/25/85669225.geojson
+++ b/data/856/692/25/85669225.geojson
@@ -278,6 +278,9 @@
         "wk:page":"Tuzla Canton"
     },
     "wof:country":"BA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f6b01203fa84d6378800832f3ff8fe66",
     "wof:hierarchy":[
         {
@@ -297,7 +300,7 @@
         "srp",
         "hrv"
     ],
-    "wof:lastmodified":1566604467,
+    "wof:lastmodified":1582321449,
     "wof:name":"Tuzla",
     "wof:parent_id":85632609,
     "wof:placetype":"region",

--- a/data/856/692/31/85669231.geojson
+++ b/data/856/692/31/85669231.geojson
@@ -309,6 +309,9 @@
         "wk:page":"Zenica-Doboj Canton"
     },
     "wof:country":"BA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"56a57120862ec7987784f464d9ee615c",
     "wof:hierarchy":[
         {
@@ -328,7 +331,7 @@
         "srp",
         "hrv"
     ],
-    "wof:lastmodified":1566604465,
+    "wof:lastmodified":1582321449,
     "wof:name":"Zenica-Doboj",
     "wof:parent_id":85632609,
     "wof:placetype":"region",

--- a/data/856/692/35/85669235.geojson
+++ b/data/856/692/35/85669235.geojson
@@ -261,6 +261,9 @@
         "wk:page":"Sarajevo Canton"
     },
     "wof:country":"BA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2fec22747c01ee9b350db3c4133acbf5",
     "wof:hierarchy":[
         {
@@ -280,7 +283,7 @@
         "srp",
         "hrv"
     ],
-    "wof:lastmodified":1566604464,
+    "wof:lastmodified":1582321448,
     "wof:name":"Sarajevo",
     "wof:parent_id":85632609,
     "wof:placetype":"region",

--- a/data/856/692/39/85669239.geojson
+++ b/data/856/692/39/85669239.geojson
@@ -288,6 +288,9 @@
         "wk:page":"Bosnian-Podrinje Canton Gora\u017ede"
     },
     "wof:country":"BA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"91f9bd35e99e210d67f74b7a4a7d9e56",
     "wof:hierarchy":[
         {
@@ -307,7 +310,7 @@
         "srp",
         "hrv"
     ],
-    "wof:lastmodified":1566604466,
+    "wof:lastmodified":1582321449,
     "wof:name":"Bosnian Podrinje",
     "wof:parent_id":85632609,
     "wof:placetype":"region",

--- a/data/856/692/43/85669243.geojson
+++ b/data/856/692/43/85669243.geojson
@@ -296,6 +296,9 @@
         "wk:page":"Posavina Canton"
     },
     "wof:country":"BA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a87c6ccb9b613333de3282558aebc16d",
     "wof:hierarchy":[
         {
@@ -315,7 +318,7 @@
         "srp",
         "hrv"
     ],
-    "wof:lastmodified":1566604465,
+    "wof:lastmodified":1582321448,
     "wof:name":"Posavina",
     "wof:parent_id":85632609,
     "wof:placetype":"region",

--- a/data/859/297/49/85929749.geojson
+++ b/data/859/297/49/85929749.geojson
@@ -128,6 +128,9 @@
         "wd:id":"Q1017960"
     },
     "wof:country":"BA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e60b790a45286cf23b2a2f75ec564bf7",
     "wof:hierarchy":[
         {
@@ -143,7 +146,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566604464,
+    "wof:lastmodified":1582321447,
     "wof:name":"Novo Sarajevo",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/518/775/890518775.geojson
+++ b/data/890/518/775/890518775.geojson
@@ -653,6 +653,9 @@
     },
     "wof:country":"BA",
     "wof:created":1469056079,
+    "wof:geom_alt":[
+        "unknown"
+    ],
     "wof:geomhash":"982297ee8745e6b2ac0b36c4240ae7f5",
     "wof:hierarchy":[
         {
@@ -664,7 +667,7 @@
         }
     ],
     "wof:id":890518775,
-    "wof:lastmodified":1566605368,
+    "wof:lastmodified":1582321470,
     "wof:name":"Sarajevo",
     "wof:parent_id":1108759181,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.