### PR TITLE
Name updates

### DIFF
--- a/data/856/326/09/85632609.geojson
+++ b/data/856/326/09/85632609.geojson
@@ -7,7 +7,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"1992-03~/1992-04~",
     "geom:area":5.755448,
-    "geom:area_square_m":51045542741.800133,
+    "geom:area_square_m":51045533212.467133,
     "geom:bbox":"15.72972,42.55653,19.621935,45.27615",
     "geom:latitude":44.167763,
     "geom:longitude":17.784389,
@@ -72,6 +72,9 @@
     "name:arg_x_preferred":[
         "Bosnia y Herzegovina"
     ],
+    "name:ary_x_preferred":[
+        "\u0628\u0648\u0635\u0646\u064a\u0627 \u0624\u0644\u0647\u0631\u0633\u0643"
+    ],
     "name:arz_x_preferred":[
         "\u0627\u0644\u0628\u0648\u0633\u0646\u0647 \u0648 \u0627\u0644\u0647\u0631\u0633\u0643"
     ],
@@ -104,6 +107,9 @@
     ],
     "name:bam_x_preferred":[
         "Bozni-\u0190rizigovini"
+    ],
+    "name:ban_x_preferred":[
+        "Bosnia"
     ],
     "name:bar_x_preferred":[
         "Bosnien-Herzegowina"
@@ -224,6 +230,12 @@
     "name:dan_x_variant":[
         "Bosnien og Hercegovina"
     ],
+    "name:deu_at_x_preferred":[
+        "Bosnien und Herzegowina"
+    ],
+    "name:deu_ch_x_preferred":[
+        "Bosnien und Herzegowina"
+    ],
     "name:deu_x_preferred":[
         "Bosnien und Herzegowina"
     ],
@@ -250,6 +262,12 @@
     ],
     "name:ell_x_variant":[
         "\u0392\u03bf\u03c3\u03bd\u03af\u03b1 - \u0395\u03c1\u03b6\u03b5\u03b3\u03bf\u03b2\u03af\u03bd\u03b7"
+    ],
+    "name:eng_ca_x_preferred":[
+        "Bosnia and Herzegovina"
+    ],
+    "name:eng_gb_x_preferred":[
+        "Bosnia and Herzegovina"
     ],
     "name:eng_x_preferred":[
         "Bosnia and Herzegovina"
@@ -300,6 +318,9 @@
         "\u0628\u0648\u0633\u0646\u06cc \u0647\u0631\u0632\u06af\u0648\u0648\u06cc\u0646",
         "\u0628\u0633\u0646\u06cc \u0648 \u0647\u0631\u0632\u06af\u0648\u06cc\u0646"
     ],
+    "name:fij_x_preferred":[
+        "Bosnia kei Herzegovina"
+    ],
     "name:fin_x_preferred":[
         "Bosnia ja Hertsegovina"
     ],
@@ -334,6 +355,9 @@
     "name:gag_x_preferred":[
         "Bosniya hem Her\u021begovina"
     ],
+    "name:gcr_x_preferred":[
+        "Bosni-\u00c8rz\u00e9govin"
+    ],
     "name:gla_x_preferred":[
         "Bosna agus Hearsagobhana"
     ],
@@ -354,6 +378,9 @@
     ],
     "name:gom_x_preferred":[
         "\u092c\u0949\u0938\u094d\u0928\u093f\u092f\u093e \u0906\u0923\u093f \u0939\u0930\u094d\u091d\u0917\u094b\u0935\u094d\u0939\u093f\u0928\u093e"
+    ],
+    "name:got_x_preferred":[
+        "\ud800\udf31\ud800\udf30\ud800\udf3f\ud800\udf43\ud800\udf3d\ud800\udf3e\ud800\udf30 & \ud800\udf37\ud800\udf30\ud800\udf42\ud800\udf3e\ud800\udf30\ud800\udf44\ud800\udf3f\ud800\udf32\ud800\udf49\ud800\udf31\ud800\udf39\ud800\udf3d\ud800\udf30"
     ],
     "name:grn_x_preferred":[
         "Vonia ha Hesegovina"
@@ -782,6 +809,9 @@
         "Bo\u015bnia I Hercegowina",
         "Bo\u015bnia i Hercegowina"
     ],
+    "name:por_br_x_preferred":[
+        "B\u00f3snia e Herzegovina"
+    ],
     "name:por_x_preferred":[
         "B\u00f3snia e Herzegovina"
     ],
@@ -893,6 +923,9 @@
     "name:srn_x_preferred":[
         "Bosnikondre"
     ],
+    "name:srp_ec_x_preferred":[
+        "\u0411\u043e\u0441\u043d\u0430 \u0438 \u0425\u0435\u0440\u0446\u0435\u0433\u043e\u0432\u0438\u043d\u0430"
+    ],
     "name:srp_x_preferred":[
         "\u0411\u043e\u0441\u043d\u0430 \u0438 \u0425\u0435\u0440\u0446\u0435\u0433\u043e\u0432\u0438\u043d\u0430"
     ],
@@ -919,6 +952,9 @@
     ],
     "name:szl_x_preferred":[
         "Bo\u015b\u0144a a Hercegowina"
+    ],
+    "name:szy_x_preferred":[
+        "Bosnia and herzegovina"
     ],
     "name:tah_x_preferred":[
         "P\u014dtinia-Heret\u014dvina"
@@ -1079,8 +1115,17 @@
     "name:zha_x_preferred":[
         "Bosnia caeuq Herzegovina"
     ],
+    "name:zho_cn_x_preferred":[
+        "\u6ce2\u65af\u5c3c\u4e9a\u548c\u9ed1\u585e\u54e5\u7ef4\u90a3"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u6ce2\u65af\u5c3c\u4e9e\u548c\u9ed1\u585e\u54e5\u7dad\u90a3"
+    ],
     "name:zho_min_nan_x_preferred":[
         "Bosna kap Hercegovina"
+    ],
+    "name:zho_tw_x_preferred":[
+        "\u6ce2\u58eb\u5c3c\u4e9e\u8207\u8d6b\u585e\u54e5\u7dad\u7d0d"
     ],
     "name:zho_x_preferred":[
         "\u6ce2\u65af\u5c3c\u4e9a\u548c\u9ed1\u585e\u54e5\u7ef4\u90a3"
@@ -1253,7 +1298,7 @@
         "srp",
         "hrv"
     ],
-    "wof:lastmodified":1583797284,
+    "wof:lastmodified":1587427956,
     "wof:name":"Bosnia and Herzegovina",
     "wof:parent_id":102191581,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1796 and https://github.com/whosonfirst-data/whosonfirst-data/issues/1821.

This PR includes:
- Fixes to property values that start or end with `" "`, `\n`, or `\r`, removing those characters.
- Using a modified version of the [wiki names import script](https://github.com/whosonfirst/whosonfirst-cookbook/blob/master/scripts/crawl_to_add_wiki_names.py), adds new `name` properties

There will be ~260 similar PRs, one for each per-country repo. No PIP work require, can merge as-is.