### PR TITLE
ba concordances, placetype local, and more

### DIFF
--- a/data/110/875/898/9/1108758989.geojson
+++ b/data/110/875/898/9/1108758989.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.140641,
-    "geom:area_square_m":1235343743.791011,
+    "geom:area_square_m":1235343971.018008,
     "geom:bbox":"16.798129,44.491362,17.301381,44.983456",
     "geom:latitude":44.736344,
     "geom:longitude":17.076167,
@@ -297,9 +297,10 @@
     "wof:concordances":{
         "hasc:id":"BA.BL.BL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323713,
-    "wof:geomhash":"96130b9d04879981fb70f13fbc88a63d",
+    "wof:geomhash":"eaa3acfaf8e6d8df7fe3991ccba17ed0",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -309,7 +310,7 @@
         }
     ],
     "wof:id":1108758989,
-    "wof:lastmodified":1636496557,
+    "wof:lastmodified":1695886723,
     "wof:name":"Banja Luka",
     "wof:parent_id":85632267,
     "wof:placetype":"county",

--- a/data/110/875/899/1/1108758991.geojson
+++ b/data/110/875/899/1/1108758991.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.020771,
-    "geom:area_square_m":183514680.929304,
+    "geom:area_square_m":183514649.071153,
     "geom:bbox":"18.316773,44.29999,18.572983,44.473027",
     "geom:latitude":44.397037,
     "geom:longitude":18.471864,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"BA.TU.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323716,
-    "wof:geomhash":"f3f4d1cc4b5f1fc24282ac2135c8416c",
+    "wof:geomhash":"1cc2114d7a570d8c5634da5cbabf090f",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108758991,
-    "wof:lastmodified":1627521585,
+    "wof:lastmodified":1695886162,
     "wof:name":"Banovici",
     "wof:parent_id":85669225,
     "wof:placetype":"county",

--- a/data/110/875/899/3/1108758993.geojson
+++ b/data/110/875/899/3/1108758993.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.107084,
-    "geom:area_square_m":941533055.541616,
+    "geom:area_square_m":941533020.411595,
     "geom:bbox":"15.72972,44.242032,16.296506,44.971018",
     "geom:latitude":44.678158,
     "geom:longitude":16.020661,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"BA.BH.BH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323717,
-    "wof:geomhash":"abf03b9b847bb5748d04e121d09e5bf6",
+    "wof:geomhash":"a127d4baa25e319a0287f4c41acb2bad",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108758993,
-    "wof:lastmodified":1627521585,
+    "wof:lastmodified":1695886162,
     "wof:name":"Bihac",
     "wof:parent_id":85669207,
     "wof:placetype":"county",

--- a/data/110/875/899/5/1108758995.geojson
+++ b/data/110/875/899/5/1108758995.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.084188,
-    "geom:area_square_m":738991923.945796,
+    "geom:area_square_m":738991937.089201,
     "geom:bbox":"18.928075,44.576975,19.373891,44.922182",
     "geom:latitude":44.774198,
     "geom:longitude":19.174504,
@@ -219,9 +219,10 @@
     "wof:concordances":{
         "hasc:id":"BA.BR.BJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323719,
-    "wof:geomhash":"58d20eed7f6a950c9987b7c5d8ab2de0",
+    "wof:geomhash":"f92c4c01357b275dc98d5f2667503661",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -231,7 +232,7 @@
         }
     ],
     "wof:id":1108758995,
-    "wof:lastmodified":1636496558,
+    "wof:lastmodified":1695886723,
     "wof:name":"Bijeljina",
     "wof:parent_id":85632267,
     "wof:placetype":"county",

--- a/data/110/875/899/7/1108758997.geojson
+++ b/data/110/875/899/7/1108758997.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.070896,
-    "geom:area_square_m":641440317.208821,
+    "geom:area_square_m":641440357.155746,
     "geom:bbox":"18.172225,42.776934,18.542095,43.136381",
     "geom:latitude":42.970972,
     "geom:longitude":18.368153,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"BA.MO.BI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323721,
-    "wof:geomhash":"4695bb2158a30834978325f2c3e265b1",
+    "wof:geomhash":"bfbb79851dfb9cf649d6571d1eb1afaf",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108758997,
-    "wof:lastmodified":1627521585,
+    "wof:lastmodified":1695886162,
     "wof:name":"Bileca",
     "wof:parent_id":85632267,
     "wof:placetype":"county",

--- a/data/110/875/899/9/1108758999.geojson
+++ b/data/110/875/899/9/1108758999.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.057581,
-    "geom:area_square_m":502198166.808155,
+    "geom:area_square_m":502198127.417529,
     "geom:bbox":"16.577016,45.046195,17.004001,45.276582",
     "geom:latitude":45.143434,
     "geom:longitude":16.812164,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"BA.PR.BD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323723,
-    "wof:geomhash":"6ecd25a2f5c5e6e280fb6dc35c7a0cde",
+    "wof:geomhash":"74f9deab8a8a062fe5b6122058833a85",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108758999,
-    "wof:lastmodified":1627521585,
+    "wof:lastmodified":1695886162,
     "wof:name":"Bosanska Dubica / Kozarska Dubica",
     "wof:parent_id":85632267,
     "wof:placetype":"county",

--- a/data/110/875/900/1/1108759001.geojson
+++ b/data/110/875/900/1/1108759001.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.087398,
-    "geom:area_square_m":763212813.538164,
+    "geom:area_square_m":763212871.114015,
     "geom:bbox":"16.910229,44.939147,17.455306,45.238965",
     "geom:latitude":45.071264,
     "geom:longitude":17.178411,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"BA.BL.BG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323725,
-    "wof:geomhash":"d0783ecedee66c36152616d27d916921",
+    "wof:geomhash":"9a74950426ec5c95fa47ddcf3373b380",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108759001,
-    "wof:lastmodified":1627521585,
+    "wof:lastmodified":1695886163,
     "wof:name":"Bosanska Gradiska / Gradiska",
     "wof:parent_id":85632267,
     "wof:placetype":"county",

--- a/data/110/875/900/3/1108759003.geojson
+++ b/data/110/875/900/3/1108759003.geojson
@@ -135,6 +135,7 @@
     "wof:concordances":{
         "hasc:id":"BA.BH.BK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323727,
     "wof:geomhash":"cb2e33146a47f6a6303aad4596707b4a",
@@ -147,7 +148,7 @@
         }
     ],
     "wof:id":1108759003,
-    "wof:lastmodified":1694497831,
+    "wof:lastmodified":1695886808,
     "wof:name":"Bosanska Krupa",
     "wof:parent_id":85669207,
     "wof:placetype":"county",

--- a/data/110/875/900/7/1108759007.geojson
+++ b/data/110/875/900/7/1108759007.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009485,
-    "geom:area_square_m":83068914.646853,
+    "geom:area_square_m":83068950.766798,
     "geom:bbox":"16.196843,44.825015,16.382903,44.988463",
     "geom:latitude":44.903016,
     "geom:longitude":16.296048,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"BA.BH.BK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323728,
-    "wof:geomhash":"3a0dacc2ecd0342787a62baf01c19f7b",
+    "wof:geomhash":"3e7456e6e4c0027ea67db6c93872ca1e",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108759007,
-    "wof:lastmodified":1627521585,
+    "wof:lastmodified":1695886163,
     "wof:name":"Bosanska Krupa / Krupa Na Uni",
     "wof:parent_id":85632267,
     "wof:placetype":"county",

--- a/data/110/875/900/9/1108759009.geojson
+++ b/data/110/875/900/9/1108759009.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.026692,
-    "geom:area_square_m":233109615.685237,
+    "geom:area_square_m":233109481.513224,
     "geom:bbox":"17.902205,44.999033,18.243061,45.151883",
     "geom:latitude":45.066882,
     "geom:longitude":18.059631,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"BA.DO.BB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323735,
-    "wof:geomhash":"bcdaad9954fbae1eb6ee4b2292227fbb",
+    "wof:geomhash":"ad06e1ed116eac2eab8636f8cde10329",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108759009,
-    "wof:lastmodified":1627521585,
+    "wof:lastmodified":1695886163,
     "wof:name":"Bosanski Brod / Srpski Brod",
     "wof:parent_id":85632267,
     "wof:placetype":"county",

--- a/data/110/875/901/1/1108759011.geojson
+++ b/data/110/875/901/1/1108759011.geojson
@@ -57,6 +57,7 @@
     "wof:concordances":{
         "hasc:id":"BA.PR.BN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323737,
     "wof:geomhash":"e0f962af3a2a48b53208605063fac212",
@@ -69,7 +70,7 @@
         }
     ],
     "wof:id":1108759011,
-    "wof:lastmodified":1694497961,
+    "wof:lastmodified":1695886163,
     "wof:name":"Bosanski Novi / Novi Grad",
     "wof:parent_id":85632267,
     "wof:placetype":"county",

--- a/data/110/875/901/3/1108759013.geojson
+++ b/data/110/875/901/3/1108759013.geojson
@@ -117,6 +117,7 @@
     "wof:concordances":{
         "hasc:id":"BA.BH.BP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323739,
     "wof:geomhash":"5d402b4af671e863e33e7811db63d5cb",
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":1108759013,
-    "wof:lastmodified":1694497831,
+    "wof:lastmodified":1695886808,
     "wof:name":"Bosanski Petrovac",
     "wof:parent_id":85669207,
     "wof:placetype":"county",

--- a/data/110/875/901/5/1108759015.geojson
+++ b/data/110/875/901/5/1108759015.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013832,
-    "geom:area_square_m":122016616.372049,
+    "geom:area_square_m":122016583.349764,
     "geom:bbox":"16.455094,44.417746,16.668667,44.53139",
     "geom:latitude":44.487781,
     "geom:longitude":16.568373,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"BA.BH.BP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323740,
-    "wof:geomhash":"0458b4ca8e8a0b084b741c1154f9f958",
+    "wof:geomhash":"b96d81a0bf5498eaf5a92ddb54b8e211",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108759015,
-    "wof:lastmodified":1627521586,
+    "wof:lastmodified":1695886163,
     "wof:name":"Bosanski Petrovac / Petrovac",
     "wof:parent_id":85632267,
     "wof:placetype":"county",

--- a/data/110/875/901/7/1108759017.geojson
+++ b/data/110/875/901/7/1108759017.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.02082,
-    "geom:area_square_m":182062870.214232,
+    "geom:area_square_m":182062929.408293,
     "geom:bbox":"18.38762,44.928873,18.637256,45.067063",
     "geom:latitude":44.99361,
     "geom:longitude":18.505084,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"BA.BR.BS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323742,
-    "wof:geomhash":"8ff65188e774dc705c3549c1411477d7",
+    "wof:geomhash":"2b8b68a5bb5b216e0a7e89a116035be9",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108759017,
-    "wof:lastmodified":1627521586,
+    "wof:lastmodified":1695886163,
     "wof:name":"Bosanski Samac / Samac",
     "wof:parent_id":85632267,
     "wof:placetype":"county",

--- a/data/110/875/901/9/1108759019.geojson
+++ b/data/110/875/901/9/1108759019.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.089609,
-    "geom:area_square_m":794996009.153655,
+    "geom:area_square_m":794995881.804759,
     "geom:bbox":"16.211438,43.963576,16.712988,44.329037",
     "geom:latitude":44.153122,
     "geom:longitude":16.462647,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"BA.LI.BO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323744,
-    "wof:geomhash":"26255f08ec5e1a1697ec6afa2805ff00",
+    "wof:geomhash":"17c28fd7868dd25cec828c5da8633165",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108759019,
-    "wof:lastmodified":1627521586,
+    "wof:lastmodified":1695886163,
     "wof:name":"Bosansko Grahovo / Grahovo",
     "wof:parent_id":85669203,
     "wof:placetype":"county",

--- a/data/110/875/902/1/1108759021.geojson
+++ b/data/110/875/902/1/1108759021.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.030825,
-    "geom:area_square_m":273355784.094849,
+    "geom:area_square_m":273355784.094882,
     "geom:bbox":"19.1074819491,44.0279154942,19.621935,44.276669",
     "geom:latitude":44.177769,
     "geom:longitude":19.323375,
@@ -132,9 +132,10 @@
     "wof:concordances":{
         "hasc:id":"BA.TU.BT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323746,
-    "wof:geomhash":"6197907a3d5c046211c55d76f5c12f60",
+    "wof:geomhash":"bf061ecd41763cc476b0735d0bf7ffd9",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -144,7 +145,7 @@
         }
     ],
     "wof:id":1108759021,
-    "wof:lastmodified":1566605098,
+    "wof:lastmodified":1695886809,
     "wof:name":"Bratunac",
     "wof:parent_id":85632267,
     "wof:placetype":"county",

--- a/data/110/875/902/5/1108759025.geojson
+++ b/data/110/875/902/5/1108759025.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.055005,
-    "geom:area_square_m":482404971.232598,
+    "geom:area_square_m":482405000.426299,
     "geom:bbox":"18.5191,44.722381,19.006743,44.965867",
     "geom:latitude":44.824327,
     "geom:longitude":18.736414,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"BA.BR.BR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323748,
-    "wof:geomhash":"b0aca292fb5214d2fdc62ce01d0c7b72",
+    "wof:geomhash":"984efd04166e2ec6a7860fe3a783fd0b",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108759025,
-    "wof:lastmodified":1627521586,
+    "wof:lastmodified":1695886164,
     "wof:name":"Brcko",
     "wof:parent_id":85632279,
     "wof:placetype":"county",

--- a/data/110/875/902/7/1108759027.geojson
+++ b/data/110/875/902/7/1108759027.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008039,
-    "geom:area_square_m":71482247.600691,
+    "geom:area_square_m":71482247.600682,
     "geom:bbox":"18.2210533693,43.9771078127,18.3718811638,44.0595982563",
     "geom:latitude":44.020279,
     "geom:longitude":18.298408,
@@ -108,9 +108,10 @@
     "wof:concordances":{
         "hasc:id":"BA.SA.BZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323754,
-    "wof:geomhash":"584a0d1e4d37907266732bdabfa9523e",
+    "wof:geomhash":"9ed96818d7827e38ba851ce45d6335eb",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -120,7 +121,7 @@
         }
     ],
     "wof:id":1108759027,
-    "wof:lastmodified":1566605098,
+    "wof:lastmodified":1695886810,
     "wof:name":"Breza",
     "wof:parent_id":85669231,
     "wof:placetype":"county",

--- a/data/110/875/902/9/1108759029.geojson
+++ b/data/110/875/902/9/1108759029.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.04054,
-    "geom:area_square_m":360364208.310383,
+    "geom:area_square_m":360364208.310382,
     "geom:bbox":"17.3171631604,43.9045527964,17.6237053932,44.1687103387",
     "geom:latitude":44.03783,
     "geom:longitude":17.467757,
@@ -153,9 +153,10 @@
     "wof:concordances":{
         "hasc:id":"BA.JJ.BU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323756,
-    "wof:geomhash":"75ef145e7f3c1dfd0372d1f9a11c1703",
+    "wof:geomhash":"c08327637174bd7b1b7e5e4f7ec1569a",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -165,7 +166,7 @@
         }
     ],
     "wof:id":1108759029,
-    "wof:lastmodified":1566605098,
+    "wof:lastmodified":1695886810,
     "wof:name":"Bugojno",
     "wof:parent_id":85669213,
     "wof:placetype":"county",

--- a/data/110/875/903/1/1108759031.geojson
+++ b/data/110/875/903/1/1108759031.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01783,
-    "geom:area_square_m":158377517.954153,
+    "geom:area_square_m":158377607.099613,
     "geom:bbox":"17.801679,44.019164,18.015462,44.164717",
     "geom:latitude":44.081799,
     "geom:longitude":17.897246,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"BA.ZE.BV"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323758,
-    "wof:geomhash":"3a3cc9e5bd263d401a90adc9a9b41b0d",
+    "wof:geomhash":"3eedd0c6be3edee5d949865500d3970c",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108759031,
-    "wof:lastmodified":1627521586,
+    "wof:lastmodified":1695886164,
     "wof:name":"Busovaca",
     "wof:parent_id":85669213,
     "wof:placetype":"county",

--- a/data/110/875/903/3/1108759033.geojson
+++ b/data/110/875/903/3/1108759033.geojson
@@ -67,7 +67,7 @@
         }
     ],
     "wof:id":1108759033,
-    "wof:lastmodified":1694497961,
+    "wof:lastmodified":1695886164,
     "wof:name":"Buzim",
     "wof:parent_id":85669207,
     "wof:placetype":"county",

--- a/data/110/875/903/5/1108759035.geojson
+++ b/data/110/875/903/5/1108759035.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.030497,
-    "geom:area_square_m":273163683.542971,
+    "geom:area_square_m":273163623.46228,
     "geom:bbox":"18.936677,43.501703,19.283391,43.665741",
     "geom:latitude":43.58321,
     "geom:longitude":19.119112,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"BA.GO.CA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323762,
-    "wof:geomhash":"e0a2f155d09c8444b258a80c827ba81b",
+    "wof:geomhash":"c64e18751a121313aa8a3c9fc8afd379",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108759035,
-    "wof:lastmodified":1627521586,
+    "wof:lastmodified":1695886164,
     "wof:name":"Cajnice",
     "wof:parent_id":85632267,
     "wof:placetype":"county",

--- a/data/110/875/903/7/1108759037.geojson
+++ b/data/110/875/903/7/1108759037.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.028422,
-    "geom:area_square_m":256595646.130102,
+    "geom:area_square_m":256595709.405312,
     "geom:bbox":"17.626343,43.002244,17.869303,43.191577",
     "geom:latitude":43.103177,
     "geom:longitude":17.738502,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"BA.MO.CP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323764,
-    "wof:geomhash":"8f090d213a4f9a10bf0ff066a2338d12",
+    "wof:geomhash":"d8c1f854a1c5bcfb72c8426d229c8f71",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108759037,
-    "wof:lastmodified":1627521586,
+    "wof:lastmodified":1695886164,
     "wof:name":"Capljina",
     "wof:parent_id":85669221,
     "wof:placetype":"county",

--- a/data/110/875/903/9/1108759039.geojson
+++ b/data/110/875/903/9/1108759039.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.040695,
-    "geom:area_square_m":355926240.008442,
+    "geom:area_square_m":355926240.008414,
     "geom:bbox":"15.740812,44.8826440463,16.0740947209,45.0835073509",
     "geom:latitude":44.982761,
     "geom:longitude":15.908125,
@@ -132,9 +132,10 @@
     "wof:concordances":{
         "hasc:id":"BA.BH.CZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323766,
-    "wof:geomhash":"75b587f32c012204f33bb7f26fffc704",
+    "wof:geomhash":"cbc203c74c1be99b281e86b32058fb89",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -144,7 +145,7 @@
         }
     ],
     "wof:id":1108759039,
-    "wof:lastmodified":1566605096,
+    "wof:lastmodified":1695886809,
     "wof:name":"Cazin",
     "wof:parent_id":85669207,
     "wof:placetype":"county",

--- a/data/110/875/904/3/1108759043.geojson
+++ b/data/110/875/904/3/1108759043.geojson
@@ -67,7 +67,7 @@
         }
     ],
     "wof:id":1108759043,
-    "wof:lastmodified":1694497961,
+    "wof:lastmodified":1695886164,
     "wof:name":"Celic",
     "wof:parent_id":85669225,
     "wof:placetype":"county",

--- a/data/110/875/904/5/1108759045.geojson
+++ b/data/110/875/904/5/1108759045.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.04118,
-    "geom:area_square_m":361796587.847147,
+    "geom:area_square_m":361796574.927032,
     "geom:bbox":"17.229586,44.634926,17.621752,44.808305",
     "geom:latitude":44.722849,
     "geom:longitude":17.430053,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"BA.BL.CE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323769,
-    "wof:geomhash":"fdd24885266b227b636d5560745fddd6",
+    "wof:geomhash":"4039e341d5e60d4098cb31c322f209b4",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108759045,
-    "wof:lastmodified":1627521586,
+    "wof:lastmodified":1695886164,
     "wof:name":"Celinac",
     "wof:parent_id":85632267,
     "wof:placetype":"county",

--- a/data/110/875/904/7/1108759047.geojson
+++ b/data/110/875/904/7/1108759047.geojson
@@ -67,7 +67,7 @@
         }
     ],
     "wof:id":1108759047,
-    "wof:lastmodified":1694497961,
+    "wof:lastmodified":1695886165,
     "wof:name":"Centar Sarajevo",
     "wof:parent_id":85669235,
     "wof:placetype":"county",

--- a/data/110/875/904/9/1108759049.geojson
+++ b/data/110/875/904/9/1108759049.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.019731,
-    "geom:area_square_m":177741169.22204,
+    "geom:area_square_m":177741175.664516,
     "geom:bbox":"17.571921,43.157827,17.803225,43.307878",
     "geom:latitude":43.23678,
     "geom:longitude":17.688017,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"BA.MO.CI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323773,
-    "wof:geomhash":"cc6e0beac18170c67d08209c38a53d6a",
+    "wof:geomhash":"0d330319e61fea6cb1a65dda35784b2e",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108759049,
-    "wof:lastmodified":1627521587,
+    "wof:lastmodified":1695886165,
     "wof:name":"Citluk",
     "wof:parent_id":85669221,
     "wof:placetype":"county",

--- a/data/110/875/905/1/1108759051.geojson
+++ b/data/110/875/905/1/1108759051.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.0585,
-    "geom:area_square_m":512002669.648605,
+    "geom:area_square_m":512002669.648623,
     "geom:bbox":"17.758123242,44.8001893758,18.1284400668,45.0751976731",
     "geom:latitude":44.943047,
     "geom:longitude":17.914959,
@@ -153,9 +153,10 @@
     "wof:concordances":{
         "hasc:id":"BA.DO.DE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323775,
-    "wof:geomhash":"2a5f8fdd7001309754096c7615f3bc76",
+    "wof:geomhash":"546d10dec4687f6e2ce76aaecdb7280f",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -165,7 +166,7 @@
         }
     ],
     "wof:id":1108759051,
-    "wof:lastmodified":1566605097,
+    "wof:lastmodified":1695886809,
     "wof:name":"Derventa",
     "wof:parent_id":85632267,
     "wof:placetype":"county",

--- a/data/110/875/905/3/1108759053.geojson
+++ b/data/110/875/905/3/1108759053.geojson
@@ -198,6 +198,7 @@
     "wof:concordances":{
         "hasc:id":"BA.DO.DO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323778,
     "wof:geomhash":"6f60a7e3ae927276c8a7b6edb8afb89e",
@@ -210,7 +211,7 @@
         }
     ],
     "wof:id":1108759053,
-    "wof:lastmodified":1694498102,
+    "wof:lastmodified":1695886723,
     "wof:name":"Doboj",
     "wof:parent_id":85632267,
     "wof:placetype":"county",

--- a/data/110/875/905/5/1108759055.geojson
+++ b/data/110/875/905/5/1108759055.geojson
@@ -67,7 +67,7 @@
         }
     ],
     "wof:id":1108759055,
-    "wof:lastmodified":1694497961,
+    "wof:lastmodified":1695886165,
     "wof:name":"Doboj - Istok",
     "wof:parent_id":85669225,
     "wof:placetype":"county",

--- a/data/110/875/905/7/1108759057.geojson
+++ b/data/110/875/905/7/1108759057.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001198,
-    "geom:area_square_m":10534007.614473,
+    "geom:area_square_m":10533979.197339,
     "geom:bbox":"18.043561,44.654971,18.087248,44.698964",
     "geom:latitude":44.676198,
     "geom:longitude":18.063427,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"BA.DO.DO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323781,
-    "wof:geomhash":"9c486f0e60a6dd3dfa736a230a6720ed",
+    "wof:geomhash":"e24a0f04b080eb54d2a8f9cf7bbb9a73",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108759057,
-    "wof:lastmodified":1627521587,
+    "wof:lastmodified":1695886165,
     "wof:name":"Doboj - Jug",
     "wof:parent_id":85669231,
     "wof:placetype":"county",

--- a/data/110/875/906/1/1108759061.geojson
+++ b/data/110/875/906/1/1108759061.geojson
@@ -67,7 +67,7 @@
         }
     ],
     "wof:id":1108759061,
-    "wof:lastmodified":1694497961,
+    "wof:lastmodified":1695886165,
     "wof:name":"Dobretici",
     "wof:parent_id":85669213,
     "wof:placetype":"county",

--- a/data/110/875/906/3/1108759063.geojson
+++ b/data/110/875/906/3/1108759063.geojson
@@ -67,7 +67,7 @@
         }
     ],
     "wof:id":1108759063,
-    "wof:lastmodified":1694497961,
+    "wof:lastmodified":1695886165,
     "wof:name":"Domaljevac - Samac",
     "wof:parent_id":85669243,
     "wof:placetype":"county",

--- a/data/110/875/906/5/1108759065.geojson
+++ b/data/110/875/906/5/1108759065.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.035895,
-    "geom:area_square_m":318443425.499704,
+    "geom:area_square_m":318443425.499709,
     "geom:bbox":"17.2596918586,44.019523984,17.5206479643,44.2629837331",
     "geom:latitude":44.155183,
     "geom:longitude":17.373164,
@@ -126,9 +126,10 @@
     "wof:concordances":{
         "hasc:id":"BA.JJ.DV"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323787,
-    "wof:geomhash":"735a5b899969d4bc39b56ee8acc0e49c",
+    "wof:geomhash":"0a0e1925bceecdbc5e4a38783e992aac",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":1108759065,
-    "wof:lastmodified":1566605089,
+    "wof:lastmodified":1695886808,
     "wof:name":"Donji Vakuf",
     "wof:parent_id":85669213,
     "wof:placetype":"county",

--- a/data/110/875/906/7/1108759067.geojson
+++ b/data/110/875/906/7/1108759067.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.065966,
-    "geom:area_square_m":583178331.736851,
+    "geom:area_square_m":583178331.736859,
     "geom:bbox":"16.2451131301,44.2316093158,16.688859873,44.4946862846",
     "geom:latitude":44.360262,
     "geom:longitude":16.454468,
@@ -144,9 +144,10 @@
     "wof:concordances":{
         "hasc:id":"BA.BH.DR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323789,
-    "wof:geomhash":"d3a7f896a67e48f1cdd59423c7f0b37f",
+    "wof:geomhash":"a13d42445bc891f8a489f395abf03ed5",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -156,7 +157,7 @@
         }
     ],
     "wof:id":1108759067,
-    "wof:lastmodified":1566605089,
+    "wof:lastmodified":1695886808,
     "wof:name":"Drvar",
     "wof:parent_id":85669203,
     "wof:placetype":"county",

--- a/data/110/875/906/9/1108759069.geojson
+++ b/data/110/875/906/9/1108759069.geojson
@@ -67,7 +67,7 @@
         }
     ],
     "wof:id":1108759069,
-    "wof:lastmodified":1694497961,
+    "wof:lastmodified":1695886165,
     "wof:name":"Drvar / Srpski Drvar",
     "wof:parent_id":85632267,
     "wof:placetype":"county",

--- a/data/110/875/907/1/1108759071.geojson
+++ b/data/110/875/907/1/1108759071.geojson
@@ -84,6 +84,7 @@
     "wof:concordances":{
         "hasc:id":"BA.GO.FC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323792,
     "wof:geomhash":"43264e52da89515eaec1506eaa81f69c",
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":1108759071,
-    "wof:lastmodified":1694497831,
+    "wof:lastmodified":1695886808,
     "wof:name":"Foca",
     "wof:parent_id":85669239,
     "wof:placetype":"county",

--- a/data/110/875/907/3/1108759073.geojson
+++ b/data/110/875/907/3/1108759073.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.12283,
-    "geom:area_square_m":1102888582.205036,
+    "geom:area_square_m":1102888610.681561,
     "geom:bbox":"18.5344,43.25233,19.080813,43.613163",
     "geom:latitude":43.435453,
     "geom:longitude":18.774983,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"BA.GO.FC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323794,
-    "wof:geomhash":"e8370ef2f9340ea8d3d7921333e1a21a",
+    "wof:geomhash":"8bf922a8179f6027aad1f847447b1bf6",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108759073,
-    "wof:lastmodified":1627521587,
+    "wof:lastmodified":1695886165,
     "wof:name":"Foca / Srbinje",
     "wof:parent_id":85632267,
     "wof:placetype":"county",

--- a/data/110/875/907/5/1108759075.geojson
+++ b/data/110/875/907/5/1108759075.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.033529,
-    "geom:area_square_m":298457610.278289,
+    "geom:area_square_m":298457610.278291,
     "geom:bbox":"17.7245000724,43.8421764347,18.0261055101,44.045916136",
     "geom:latitude":43.95487,
     "geom:longitude":17.888596,
@@ -111,9 +111,10 @@
     "wof:concordances":{
         "hasc:id":"BA.SA.FJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323796,
-    "wof:geomhash":"5d87aca4e17299105f038241bdb1d7a4",
+    "wof:geomhash":"abdf14c06b4751e2dad89edf53fcd01b",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -123,7 +124,7 @@
         }
     ],
     "wof:id":1108759075,
-    "wof:lastmodified":1566605087,
+    "wof:lastmodified":1695886808,
     "wof:name":"Fojnica",
     "wof:parent_id":85669213,
     "wof:placetype":"county",

--- a/data/110/875/907/9/1108759079.geojson
+++ b/data/110/875/907/9/1108759079.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.080747,
-    "geom:area_square_m":727846435.217127,
+    "geom:area_square_m":727846435.217165,
     "geom:bbox":"18.3310220844,43.029186,18.717157,43.3546348773",
     "geom:latitude":43.199259,
     "geom:longitude":18.522449,
@@ -129,9 +129,10 @@
     "wof:concordances":{
         "hasc:id":"BA.MO.GA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323798,
-    "wof:geomhash":"449d505619d003303f5b4991ccbcf1ee",
+    "wof:geomhash":"c0d61840b564a7e7c8097450340aefc1",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":1108759079,
-    "wof:lastmodified":1566605086,
+    "wof:lastmodified":1695886808,
     "wof:name":"Gacko",
     "wof:parent_id":85632267,
     "wof:placetype":"county",

--- a/data/110/875/908/1/1108759081.geojson
+++ b/data/110/875/908/1/1108759081.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.11703,
-    "geom:area_square_m":1039196097.222551,
+    "geom:area_square_m":1039196078.300073,
     "geom:bbox":"16.598401,43.874724,17.099851,44.324818",
     "geom:latitude":44.100313,
     "geom:longitude":16.859665,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"BA.LI.GL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323800,
-    "wof:geomhash":"84248b4980665663800cd523db38a7bc",
+    "wof:geomhash":"6a0bf4b427dce4fed725b106527395bd",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108759081,
-    "wof:lastmodified":1627521587,
+    "wof:lastmodified":1695886165,
     "wof:name":"Glamoc",
     "wof:parent_id":85669203,
     "wof:placetype":"county",

--- a/data/110/875/908/3/1108759083.geojson
+++ b/data/110/875/908/3/1108759083.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.027325,
-    "geom:area_square_m":244409962.337318,
+    "geom:area_square_m":244409902.315433,
     "geom:bbox":"18.715924,43.586852,19.004193,43.727495",
     "geom:latitude":43.666707,
     "geom:longitude":18.871997,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"BA.GO.GO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323801,
-    "wof:geomhash":"3a64a89c1bc598c8be375088de32f94e",
+    "wof:geomhash":"e0b6f28d7f210ab58b0e7f0136e1c318",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108759083,
-    "wof:lastmodified":1627521587,
+    "wof:lastmodified":1695886166,
     "wof:name":"Gorazde",
     "wof:parent_id":85669239,
     "wof:placetype":"county",

--- a/data/110/875/908/5/1108759085.geojson
+++ b/data/110/875/908/5/1108759085.geojson
@@ -67,7 +67,7 @@
         }
     ],
     "wof:id":1108759085,
-    "wof:lastmodified":1694497961,
+    "wof:lastmodified":1695886166,
     "wof:name":"Gorazde / Srpsko Gorazde",
     "wof:parent_id":85632267,
     "wof:placetype":"county",

--- a/data/110/875/908/7/1108759087.geojson
+++ b/data/110/875/908/7/1108759087.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.045074,
-    "geom:area_square_m":401403722.148812,
+    "geom:area_square_m":401403640.254298,
     "geom:bbox":"17.446581,43.833266,17.849541,44.048289",
     "geom:latitude":43.92922,
     "geom:longitude":17.635137,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"BA.JJ.GV"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323805,
-    "wof:geomhash":"6fe126d3ea8e5d288e03d37d52d7da30",
+    "wof:geomhash":"d3ccc66a325dd45a0e7b773068cfb300",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108759087,
-    "wof:lastmodified":1627521587,
+    "wof:lastmodified":1695886166,
     "wof:name":"Gornji Vakuf",
     "wof:parent_id":85669213,
     "wof:placetype":"county",

--- a/data/110/875/908/9/1108759089.geojson
+++ b/data/110/875/908/9/1108759089.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.025854,
-    "geom:area_square_m":227130024.908136,
+    "geom:area_square_m":227129922.760064,
     "geom:bbox":"18.173076,44.613404,18.454848,44.805297",
     "geom:latitude":44.727909,
     "geom:longitude":18.329827,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"BA.TU.GC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323808,
-    "wof:geomhash":"c6b6bd26a68e721d44600f9d5ed2fb27",
+    "wof:geomhash":"dab684e140e09d39b1f9413289f5d768",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108759089,
-    "wof:lastmodified":1627521588,
+    "wof:lastmodified":1695886166,
     "wof:name":"Gracanica",
     "wof:parent_id":85669225,
     "wof:placetype":"county",

--- a/data/110/875/909/1/1108759091.geojson
+++ b/data/110/875/909/1/1108759091.geojson
@@ -67,7 +67,7 @@
         }
     ],
     "wof:id":1108759091,
-    "wof:lastmodified":1694497961,
+    "wof:lastmodified":1695886166,
     "wof:name":"Gracanica / Petrovo",
     "wof:parent_id":85632267,
     "wof:placetype":"county",

--- a/data/110/875/909/3/1108759093.geojson
+++ b/data/110/875/909/3/1108759093.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.024698,
-    "geom:area_square_m":216544942.624604,
+    "geom:area_square_m":216544933.017473,
     "geom:bbox":"18.317364,44.764392,18.58609,44.918458",
     "geom:latitude":44.840212,
     "geom:longitude":18.443888,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"BA.BR.GD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323811,
-    "wof:geomhash":"34344386391b6b82c7e4962f4b604bb9",
+    "wof:geomhash":"2c09d82fcf6aa2a2a1b2767e9041a6fd",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108759093,
-    "wof:lastmodified":1627521588,
+    "wof:lastmodified":1695886166,
     "wof:name":"Gradacac",
     "wof:parent_id":85669225,
     "wof:placetype":"county",

--- a/data/110/875/909/7/1108759097.geojson
+++ b/data/110/875/909/7/1108759097.geojson
@@ -67,7 +67,7 @@
         }
     ],
     "wof:id":1108759097,
-    "wof:lastmodified":1694497961,
+    "wof:lastmodified":1695886166,
     "wof:name":"Gradacac / Pelagicevo",
     "wof:parent_id":85632267,
     "wof:placetype":"county",

--- a/data/110/875/909/9/1108759099.geojson
+++ b/data/110/875/909/9/1108759099.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.025079,
-    "geom:area_square_m":225477526.856319,
+    "geom:area_square_m":225477526.856312,
     "geom:bbox":"17.251085,43.2780600149,17.5103168599,43.4470831263",
     "geom:latitude":43.356653,
     "geom:longitude":17.373278,
@@ -123,9 +123,10 @@
     "wof:concordances":{
         "hasc:id":"BA.LI.GR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323815,
-    "wof:geomhash":"6e8b0ef53bd398b0db4179378ff5b411",
+    "wof:geomhash":"ba9c076300ed378ac1e31e5072bdf32f",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":1108759099,
-    "wof:lastmodified":1566605085,
+    "wof:lastmodified":1695886808,
     "wof:name":"Grude",
     "wof:parent_id":85669217,
     "wof:placetype":"county",

--- a/data/110/875/910/1/1108759101.geojson
+++ b/data/110/875/910/1/1108759101.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.030338,
-    "geom:area_square_m":270884768.06372,
+    "geom:area_square_m":270884820.222665,
     "geom:bbox":"18.011717,43.689362,18.276944,43.863297",
     "geom:latitude":43.771362,
     "geom:longitude":18.154269,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"BA.SA.HA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323816,
-    "wof:geomhash":"7fb436a5bf1d19224c3d6b186be047ed",
+    "wof:geomhash":"d372e16d71e4c08dab66f2d1bbd1b88a",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108759101,
-    "wof:lastmodified":1627521588,
+    "wof:lastmodified":1695886166,
     "wof:name":"Hadzici",
     "wof:parent_id":85669235,
     "wof:placetype":"county",

--- a/data/110/875/910/3/1108759103.geojson
+++ b/data/110/875/910/3/1108759103.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.038491,
-    "geom:area_square_m":341976842.643244,
+    "geom:area_square_m":341976842.643225,
     "geom:bbox":"18.7562814324,43.9756611741,19.1484070569,44.1700229543",
     "geom:latitude":44.068386,
     "geom:longitude":18.948089,
@@ -111,9 +111,10 @@
     "wof:concordances":{
         "hasc:id":"BA.SA.HP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323818,
-    "wof:geomhash":"9a6e5b586e2b407174781fe74a31baf3",
+    "wof:geomhash":"2da292a6ccadfbb923019edd392d9b20",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -123,7 +124,7 @@
         }
     ],
     "wof:id":1108759103,
-    "wof:lastmodified":1566605109,
+    "wof:lastmodified":1695886811,
     "wof:name":"Han Pijesak",
     "wof:parent_id":85632267,
     "wof:placetype":"county",

--- a/data/110/875/910/5/1108759105.geojson
+++ b/data/110/875/910/5/1108759105.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015576,
-    "geom:area_square_m":138961870.587717,
+    "geom:area_square_m":138961702.073495,
     "geom:bbox":"18.175595,43.735269,18.398593,43.913993",
     "geom:latitude":43.82121,
     "geom:longitude":18.28348,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"BA.SA.IZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323820,
-    "wof:geomhash":"95655f6612ecc109306375fbf3abbee1",
+    "wof:geomhash":"58d7c6369823447cf6d96a0b901bf417",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108759105,
-    "wof:lastmodified":1627521588,
+    "wof:lastmodified":1695886167,
     "wof:name":"Ilidza",
     "wof:parent_id":85669235,
     "wof:placetype":"county",

--- a/data/110/875/910/7/1108759107.geojson
+++ b/data/110/875/910/7/1108759107.geojson
@@ -67,7 +67,7 @@
         }
     ],
     "wof:id":1108759107,
-    "wof:lastmodified":1694497961,
+    "wof:lastmodified":1695886167,
     "wof:name":"Ilidza / Srpska Ilidza",
     "wof:parent_id":85632267,
     "wof:placetype":"county",

--- a/data/110/875/910/9/1108759109.geojson
+++ b/data/110/875/910/9/1108759109.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.03324,
-    "geom:area_square_m":295606036.654256,
+    "geom:area_square_m":295606213.62155,
     "geom:bbox":"18.221198,43.896518,18.613709,44.119149",
     "geom:latitude":44.010669,
     "geom:longitude":18.43297,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"BA.SA.IJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323824,
-    "wof:geomhash":"095ed8eb516fb6c12a421b8057df0ced",
+    "wof:geomhash":"8be8bacb9da2a641d6bb583741f74fce",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108759109,
-    "wof:lastmodified":1627521588,
+    "wof:lastmodified":1695886167,
     "wof:name":"Ilijas",
     "wof:parent_id":85669235,
     "wof:placetype":"county",

--- a/data/110/875/911/1/1108759111.geojson
+++ b/data/110/875/911/1/1108759111.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.033697,
-    "geom:area_square_m":301449347.698087,
+    "geom:area_square_m":301449347.698088,
     "geom:bbox":"17.5025143338,43.5572843267,17.8738069213,43.7389344001",
     "geom:latitude":43.658554,
     "geom:longitude":17.70961,
@@ -117,9 +117,10 @@
     "wof:concordances":{
         "hasc:id":"BA.MO.JB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323826,
-    "wof:geomhash":"9e730016d5847fd36f945f4c5f39b232",
+    "wof:geomhash":"7d9a4a91bd7de59aa949f5379673f44b",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":1108759111,
-    "wof:lastmodified":1566605100,
+    "wof:lastmodified":1695886810,
     "wof:name":"Jablanica",
     "wof:parent_id":85669221,
     "wof:placetype":"county",

--- a/data/110/875/911/5/1108759115.geojson
+++ b/data/110/875/911/5/1108759115.geojson
@@ -153,6 +153,7 @@
     "wof:concordances":{
         "hasc:id":"BA.JJ.JC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323833,
     "wof:geomhash":"a76f1c7b92dcd9a4d0cefa38ca4163fd",
@@ -165,7 +166,7 @@
         }
     ],
     "wof:id":1108759115,
-    "wof:lastmodified":1694497832,
+    "wof:lastmodified":1695886810,
     "wof:name":"Jajce",
     "wof:parent_id":85669213,
     "wof:placetype":"county",

--- a/data/110/875/911/7/1108759117.geojson
+++ b/data/110/875/911/7/1108759117.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008092,
-    "geom:area_square_m":71569340.766065,
+    "geom:area_square_m":71569433.513564,
     "geom:bbox":"17.114299,44.254886,17.242711,44.4151",
     "geom:latitude":44.333427,
     "geom:longitude":17.185315,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"BA.JJ.JC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323834,
-    "wof:geomhash":"cb48df0e95eacc7bdcb97a20f6fd0a9a",
+    "wof:geomhash":"5f5f198d475b2a4987fc5b1c57f7d4c7",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108759117,
-    "wof:lastmodified":1627521588,
+    "wof:lastmodified":1695886167,
     "wof:name":"Jajce / Jezero",
     "wof:parent_id":85632267,
     "wof:placetype":"county",

--- a/data/110/875/911/9/1108759119.geojson
+++ b/data/110/875/911/9/1108759119.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.042345,
-    "geom:area_square_m":375604733.906862,
+    "geom:area_square_m":375604733.906911,
     "geom:bbox":"17.9638331289,44.0558880839,18.2861596849,44.2987300159",
     "geom:latitude":44.164208,
     "geom:longitude":18.136684,
@@ -123,9 +123,10 @@
     "wof:concordances":{
         "hasc:id":"BA.ZE.KK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323836,
-    "wof:geomhash":"73eb5605464987cd3f71c4192acf61eb",
+    "wof:geomhash":"d5ca370b1ba2dd9aabe9b00078e644cf",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":1108759119,
-    "wof:lastmodified":1566605100,
+    "wof:lastmodified":1695886810,
     "wof:name":"Kakanj",
     "wof:parent_id":85669231,
     "wof:placetype":"county",

--- a/data/110/875/912/1/1108759121.geojson
+++ b/data/110/875/912/1/1108759121.geojson
@@ -105,6 +105,7 @@
     "wof:concordances":{
         "hasc:id":"BA.TU.KA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323839,
     "wof:geomhash":"1cc19203798a9ef6700d9d133717f223",
@@ -117,7 +118,7 @@
         }
     ],
     "wof:id":1108759121,
-    "wof:lastmodified":1694497831,
+    "wof:lastmodified":1695886809,
     "wof:name":"Kalesija",
     "wof:parent_id":85669225,
     "wof:placetype":"county",

--- a/data/110/875/912/3/1108759123.geojson
+++ b/data/110/875/912/3/1108759123.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009249,
-    "geom:area_square_m":81722110.725489,
+    "geom:area_square_m":81722184.413577,
     "geom:bbox":"18.84782,44.349896,19.027499,44.44271",
     "geom:latitude":44.39072,
     "geom:longitude":18.942443,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"BA.TU.KA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323841,
-    "wof:geomhash":"5944e54cbf8dfce157038504b5dd14ec",
+    "wof:geomhash":"7d52db03d983f3e3687a174751e6de8a",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108759123,
-    "wof:lastmodified":1627521588,
+    "wof:lastmodified":1695886167,
     "wof:name":"Kalesija / Osmaci",
     "wof:parent_id":85632267,
     "wof:placetype":"county",

--- a/data/110/875/912/5/1108759125.geojson
+++ b/data/110/875/912/5/1108759125.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.075316,
-    "geom:area_square_m":675940161.691865,
+    "geom:area_square_m":675940161.691854,
     "geom:bbox":"18.179960715,43.3087500406,18.596116499,43.631802431",
     "geom:latitude":43.46443,
     "geom:longitude":18.419025,
@@ -129,9 +129,10 @@
     "wof:concordances":{
         "hasc:id":"BA.SA.KN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323842,
-    "wof:geomhash":"12f8344485f2ea38320bb140d2deb086",
+    "wof:geomhash":"57fb9e707ae0517dd144438d96bc6741",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":1108759125,
-    "wof:lastmodified":1566605092,
+    "wof:lastmodified":1695886809,
     "wof:name":"Kalinovik",
     "wof:parent_id":85632267,
     "wof:placetype":"county",

--- a/data/110/875/912/7/1108759127.geojson
+++ b/data/110/875/912/7/1108759127.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017847,
-    "geom:area_square_m":158885043.728113,
+    "geom:area_square_m":158885043.728124,
     "geom:bbox":"17.9401275869,43.8192615932,18.1841516798,44.051641159",
     "geom:latitude":43.947237,
     "geom:longitude":18.074534,
@@ -120,9 +120,10 @@
     "wof:concordances":{
         "hasc:id":"BA.SA.KI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323845,
-    "wof:geomhash":"5ac99e5b8f50840994b8aec90413d636",
+    "wof:geomhash":"f9a8cab2fce07d3e4107502ae8afc333",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":1108759127,
-    "wof:lastmodified":1566605092,
+    "wof:lastmodified":1695886809,
     "wof:name":"Kiseljak",
     "wof:parent_id":85669213,
     "wof:placetype":"county",

--- a/data/110/875/912/9/1108759129.geojson
+++ b/data/110/875/912/9/1108759129.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.037279,
-    "geom:area_square_m":330128998.231728,
+    "geom:area_square_m":330128998.231727,
     "geom:bbox":"18.5366230718,44.1650905289,18.8364465326,44.3799796043",
     "geom:latitude":44.260575,
     "geom:longitude":18.679837,
@@ -111,9 +111,10 @@
     "wof:concordances":{
         "hasc:id":"BA.TU.KD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323847,
-    "wof:geomhash":"03506832f216e9769ced7972961c0868",
+    "wof:geomhash":"b1c85f9b8404fe54720738f8d18f9449",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -123,7 +124,7 @@
         }
     ],
     "wof:id":1108759129,
-    "wof:lastmodified":1566605092,
+    "wof:lastmodified":1695886809,
     "wof:name":"Kladanj",
     "wof:parent_id":85669225,
     "wof:placetype":"county",

--- a/data/110/875/913/3/1108759133.geojson
+++ b/data/110/875/913/3/1108759133.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.039581,
-    "geom:area_square_m":348539366.999959,
+    "geom:area_square_m":348539313.18619,
     "geom:bbox":"16.527669,44.519113,16.904204,44.668161",
     "geom:latitude":44.590274,
     "geom:longitude":16.730858,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"BA.PR.KC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323848,
-    "wof:geomhash":"9c40c66edcd0f665b372dfcd796d5cb8",
+    "wof:geomhash":"7aba6c683c3b480746fee4ae8c3f408f",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108759133,
-    "wof:lastmodified":1627521588,
+    "wof:lastmodified":1695886167,
     "wof:name":"Kljuc",
     "wof:parent_id":85669207,
     "wof:placetype":"county",

--- a/data/110/875/913/5/1108759135.geojson
+++ b/data/110/875/913/5/1108759135.geojson
@@ -67,7 +67,7 @@
         }
     ],
     "wof:id":1108759135,
-    "wof:lastmodified":1694497961,
+    "wof:lastmodified":1695886167,
     "wof:name":"Kljuc / Ribnik",
     "wof:parent_id":85632267,
     "wof:placetype":"county",

--- a/data/110/875/913/7/1108759137.geojson
+++ b/data/110/875/913/7/1108759137.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.125547,
-    "geom:area_square_m":1123375024.901045,
+    "geom:area_square_m":1123375024.901021,
     "geom:bbox":"17.7169633829,43.4696412012,18.3577570402,43.893171039",
     "geom:latitude":43.644937,
     "geom:longitude":18.032099,
@@ -144,9 +144,10 @@
     "wof:concordances":{
         "hasc:id":"BA.MO.KO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323852,
-    "wof:geomhash":"cba4e0e3d293ca25428fe9550816e765",
+    "wof:geomhash":"9f8046c089271eaa343691bf70dd1aa8",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -156,7 +157,7 @@
         }
     ],
     "wof:id":1108759137,
-    "wof:lastmodified":1566605095,
+    "wof:lastmodified":1695886809,
     "wof:name":"Konjic",
     "wof:parent_id":85669221,
     "wof:placetype":"county",

--- a/data/110/875/913/9/1108759139.geojson
+++ b/data/110/875/913/9/1108759139.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009088,
-    "geom:area_square_m":79208572.528844,
+    "geom:area_square_m":79208572.528836,
     "geom:bbox":"16.4798586817,45.1206444868,16.6284929056,45.230555",
     "geom:latitude":45.181627,
     "geom:longitude":16.562603,
@@ -99,9 +99,10 @@
     "wof:concordances":{
         "hasc:id":"BA.PR.BN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323854,
-    "wof:geomhash":"24aa47d95e44806de515d3510c1b9ca4",
+    "wof:geomhash":"f04cd71ec740993cee8ce82b8608fd2c",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1108759139,
-    "wof:lastmodified":1566605095,
+    "wof:lastmodified":1695886809,
     "wof:name":"Kostajnica",
     "wof:parent_id":85632267,
     "wof:placetype":"county",

--- a/data/110/875/914/1/1108759141.geojson
+++ b/data/110/875/914/1/1108759141.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.063266,
-    "geom:area_square_m":557596487.858072,
+    "geom:area_square_m":557596458.441483,
     "geom:bbox":"17.257591,44.350549,17.701795,44.686986",
     "geom:latitude":44.539187,
     "geom:longitude":17.495797,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"BA.BL.KV"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323856,
-    "wof:geomhash":"31b126614cd4b53e6cfa23de0fefc1ff",
+    "wof:geomhash":"30c55591ed25a94b252898a248ca976e",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108759141,
-    "wof:lastmodified":1627521589,
+    "wof:lastmodified":1695886167,
     "wof:name":"Kotor Varos",
     "wof:parent_id":85632267,
     "wof:placetype":"county",

--- a/data/110/875/914/3/1108759143.geojson
+++ b/data/110/875/914/3/1108759143.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016627,
-    "geom:area_square_m":148249694.372934,
+    "geom:area_square_m":148249685.418492,
     "geom:bbox":"17.918126,43.79807,18.121746,43.929498",
     "geom:latitude":43.858058,
     "geom:longitude":18.024604,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"BA.SA.KR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323857,
-    "wof:geomhash":"830b4a3ca6754d7bcca4d295c61b7a1d",
+    "wof:geomhash":"9b8935aa02d999d00bb1ec728e34758d",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108759143,
-    "wof:lastmodified":1627521589,
+    "wof:lastmodified":1695886167,
     "wof:name":"Kresevo",
     "wof:parent_id":85669213,
     "wof:placetype":"county",

--- a/data/110/875/914/5/1108759145.geojson
+++ b/data/110/875/914/5/1108759145.geojson
@@ -99,6 +99,7 @@
     "wof:concordances":{
         "hasc:id":"BA.LI.KU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323859,
     "wof:geomhash":"995ff2d9aef1cca38e9b1f0584787067",
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1108759145,
-    "wof:lastmodified":1694497832,
+    "wof:lastmodified":1695886809,
     "wof:name":"Kupres",
     "wof:parent_id":85669203,
     "wof:placetype":"county",

--- a/data/110/875/914/7/1108759147.geojson
+++ b/data/110/875/914/7/1108759147.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004333,
-    "geom:area_square_m":38490096.832582,
+    "geom:area_square_m":38490118.048348,
     "geom:bbox":"17.09588,44.065127,17.264159,44.111422",
     "geom:latitude":44.084312,
     "geom:longitude":17.176052,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"BA.LI.KU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323861,
-    "wof:geomhash":"fe80341e0c0ed4da5ca78c16e180f300",
+    "wof:geomhash":"abb531e3ecc1a8c4dc76031e8f0ce23b",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108759147,
-    "wof:lastmodified":1627521589,
+    "wof:lastmodified":1695886168,
     "wof:name":"Kupres / Srpski Kupres",
     "wof:parent_id":85632267,
     "wof:placetype":"county",

--- a/data/110/875/915/1/1108759151.geojson
+++ b/data/110/875/915/1/1108759151.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.043935,
-    "geom:area_square_m":384901542.49126,
+    "geom:area_square_m":384901582.679277,
     "geom:bbox":"17.179387,44.776953,17.471985,44.990446",
     "geom:latitude":44.887771,
     "geom:longitude":17.338483,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"BA.BL.LA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323863,
-    "wof:geomhash":"e1177c2d8e9676cc1b2c7dc46d14114e",
+    "wof:geomhash":"cd2a9539c4f4a18f272eb9c3634e2e2d",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108759151,
-    "wof:lastmodified":1627521589,
+    "wof:lastmodified":1695886168,
     "wof:name":"Laktasi",
     "wof:parent_id":85632267,
     "wof:placetype":"county",

--- a/data/110/875/915/3/1108759153.geojson
+++ b/data/110/875/915/3/1108759153.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.11209,
-    "geom:area_square_m":999553176.606482,
+    "geom:area_square_m":999553176.606448,
     "geom:bbox":"16.5463718301,43.6618172545,17.1701519065,44.0496666727",
     "geom:latitude":43.848561,
     "geom:longitude":16.875307,
@@ -162,9 +162,10 @@
     "wof:concordances":{
         "hasc:id":"BA.LI.LV"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323865,
-    "wof:geomhash":"4d7ffcc155c2506f0fbdbeb851ef2d50",
+    "wof:geomhash":"0f7898804bea64c288543e3f7c116a3f",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -174,7 +175,7 @@
         }
     ],
     "wof:id":1108759153,
-    "wof:lastmodified":1566605091,
+    "wof:lastmodified":1695886808,
     "wof:name":"Livno",
     "wof:parent_id":85669203,
     "wof:placetype":"county",

--- a/data/110/875/915/5/1108759155.geojson
+++ b/data/110/875/915/5/1108759155.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.038363,
-    "geom:area_square_m":347208847.007611,
+    "geom:area_square_m":347208847.007607,
     "geom:bbox":"17.936798367,42.8361267722,18.2780611609,43.062581293",
     "geom:latitude":42.950242,
     "geom:longitude":18.120026,
@@ -111,9 +111,10 @@
     "wof:concordances":{
         "hasc:id":"BA.MO.LN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323866,
-    "wof:geomhash":"547cf06eb3adae80797e011d5e25aa15",
+    "wof:geomhash":"e26f8a4464a55ea8b6987c7c66256e11",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -123,7 +124,7 @@
         }
     ],
     "wof:id":1108759155,
-    "wof:lastmodified":1566605092,
+    "wof:lastmodified":1695886809,
     "wof:name":"Ljubinje",
     "wof:parent_id":85632267,
     "wof:placetype":"county",

--- a/data/110/875/915/7/1108759157.geojson
+++ b/data/110/875/915/7/1108759157.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.033588,
-    "geom:area_square_m":302676492.381164,
+    "geom:area_square_m":302676681.855092,
     "geom:bbox":"17.329878,43.095598,17.662704,43.314292",
     "geom:latitude":43.216116,
     "geom:longitude":17.515078,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"BA.MO.LB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323868,
-    "wof:geomhash":"bfef858c937148c1532f31ca02467f88",
+    "wof:geomhash":"dd6657cc51eabe5d27be3b30f7569e4e",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108759157,
-    "wof:lastmodified":1627521589,
+    "wof:lastmodified":1695886168,
     "wof:name":"Ljubuski",
     "wof:parent_id":85669217,
     "wof:placetype":"county",

--- a/data/110/875/915/9/1108759159.geojson
+++ b/data/110/875/915/9/1108759159.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.035394,
-    "geom:area_square_m":311342826.73779,
+    "geom:area_square_m":311342826.73778,
     "geom:bbox":"18.731102058,44.5320696436,18.9736388602,44.7833034975",
     "geom:latitude":44.65253,
     "geom:longitude":18.861054,
@@ -108,9 +108,10 @@
     "wof:concordances":{
         "hasc:id":"BA.TU.LO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323870,
-    "wof:geomhash":"84d3546ab19d9bd01f72a139c6301ce0",
+    "wof:geomhash":"f8e1dfa3ff68d562133ef8b028d11979",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -120,7 +121,7 @@
         }
     ],
     "wof:id":1108759159,
-    "wof:lastmodified":1566605091,
+    "wof:lastmodified":1695886809,
     "wof:name":"Lopare",
     "wof:parent_id":85632267,
     "wof:placetype":"county",

--- a/data/110/875/916/1/1108759161.geojson
+++ b/data/110/875/916/1/1108759161.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.039069,
-    "geom:area_square_m":344348740.380648,
+    "geom:area_square_m":344348740.380653,
     "geom:bbox":"18.288155701,44.4300816421,18.5809720601,44.6468731795",
     "geom:latitude":44.537785,
     "geom:longitude":18.446257,
@@ -126,9 +126,10 @@
     "wof:concordances":{
         "hasc:id":"BA.TU.LU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323873,
-    "wof:geomhash":"0e331adf6cbe166090bdccbf7ff15c12",
+    "wof:geomhash":"67ad99da20eb6db7ccbe360e47df0c0f",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":1108759161,
-    "wof:lastmodified":1566605101,
+    "wof:lastmodified":1695886810,
     "wof:name":"Lukavac",
     "wof:parent_id":85669225,
     "wof:placetype":"county",

--- a/data/110/875/916/3/1108759163.geojson
+++ b/data/110/875/916/3/1108759163.geojson
@@ -117,9 +117,10 @@
     "wof:concordances":{
         "hasc:id":"BA.DO.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323874,
-    "wof:geomhash":"c3ceab2088da505cea639e4255535dd2",
+    "wof:geomhash":"4858586f9f4a7901cc30ce4a8c3d23d4",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":1108759163,
-    "wof:lastmodified":1566605101,
+    "wof:lastmodified":1695886810,
     "wof:name":"Maglaj",
     "wof:parent_id":85669231,
     "wof:placetype":"county",

--- a/data/110/875/916/5/1108759165.geojson
+++ b/data/110/875/916/5/1108759165.geojson
@@ -57,6 +57,7 @@
     "wof:concordances":{
         "hasc:id":"BA.TU.VL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323876,
     "wof:geomhash":"99774f2cce5cf6f999c437af3a328711",
@@ -69,7 +70,7 @@
         }
     ],
     "wof:id":1108759165,
-    "wof:lastmodified":1694497961,
+    "wof:lastmodified":1695886168,
     "wof:name":"Milici",
     "wof:parent_id":85632267,
     "wof:placetype":"county",

--- a/data/110/875/916/9/1108759169.geojson
+++ b/data/110/875/916/9/1108759169.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.033146,
-    "geom:area_square_m":290122222.720611,
+    "geom:area_square_m":290122216.937961,
     "geom:bbox":"18.123229,44.844571,18.450238,45.020082",
     "geom:latitude":44.939213,
     "geom:longitude":18.261545,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"BA.DO.MD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323878,
-    "wof:geomhash":"e84dd02102b975adf245a8b87e358363",
+    "wof:geomhash":"0f65a7f739285a8e5cef4ee51200a0d5",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108759169,
-    "wof:lastmodified":1627521589,
+    "wof:lastmodified":1695886168,
     "wof:name":"Modrica",
     "wof:parent_id":85632267,
     "wof:placetype":"county",

--- a/data/110/875/917/1/1108759171.geojson
+++ b/data/110/875/917/1/1108759171.geojson
@@ -60,6 +60,7 @@
     "wof:concordances":{
         "hasc:id":"BA.MO.MS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323880,
     "wof:geomhash":"a4104bd99a50812cc05527171c27f49a",
@@ -72,7 +73,7 @@
         }
     ],
     "wof:id":1108759171,
-    "wof:lastmodified":1694639716,
+    "wof:lastmodified":1695886168,
     "wof:name":"Mostar",
     "wof:parent_id":85669221,
     "wof:placetype":"county",

--- a/data/110/875/917/3/1108759173.geojson
+++ b/data/110/875/917/3/1108759173.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006144,
-    "geom:area_square_m":55188152.373696,
+    "geom:area_square_m":55188272.071748,
     "geom:bbox":"17.965074,43.359775,18.05119,43.471147",
     "geom:latitude":43.411488,
     "geom:longitude":18.010664,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"BA.MO.MS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323882,
-    "wof:geomhash":"e9bd826e960e8ac1dac5cf35ca189e90",
+    "wof:geomhash":"f6369ec82816563c8aadf3137802eb08",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108759173,
-    "wof:lastmodified":1627521589,
+    "wof:lastmodified":1695886168,
     "wof:name":"Mostar / Srpski Mostar",
     "wof:parent_id":85632267,
     "wof:placetype":"county",

--- a/data/110/875/917/5/1108759175.geojson
+++ b/data/110/875/917/5/1108759175.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.074482,
-    "geom:area_square_m":658078883.714867,
+    "geom:area_square_m":658078990.561198,
     "geom:bbox":"16.798433,44.195981,17.25295,44.578826",
     "geom:latitude":44.39439,
     "geom:longitude":17.017801,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"BA.JJ.MG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323883,
-    "wof:geomhash":"5617d1cf1092cdf3ed60aa5e8a490210",
+    "wof:geomhash":"d9b6940d8613c847d4579ec1fd68863f",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108759175,
-    "wof:lastmodified":1627521589,
+    "wof:lastmodified":1695886168,
     "wof:name":"Mrkonjic Grad",
     "wof:parent_id":85632267,
     "wof:placetype":"county",

--- a/data/110/875/917/7/1108759177.geojson
+++ b/data/110/875/917/7/1108759177.geojson
@@ -166,7 +166,7 @@
         }
     ],
     "wof:id":1108759177,
-    "wof:lastmodified":1694497832,
+    "wof:lastmodified":1695886811,
     "wof:name":"Neum",
     "wof:parent_id":85669221,
     "wof:placetype":"county",

--- a/data/110/875/917/9/1108759179.geojson
+++ b/data/110/875/917/9/1108759179.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.103311,
-    "geom:area_square_m":930146476.219907,
+    "geom:area_square_m":930146476.219881,
     "geom:bbox":"17.9584289459,43.0733254936,18.4188599527,43.4788208221",
     "geom:latitude":43.270994,
     "geom:longitude":18.183551,
@@ -123,9 +123,10 @@
     "wof:concordances":{
         "hasc:id":"BA.MO.NE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323887,
-    "wof:geomhash":"b277d7ee39eb8505585d20eb52ceb838",
+    "wof:geomhash":"86b3d6b4138a1e8a60a52fd5eaf173f7",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":1108759179,
-    "wof:lastmodified":1566605107,
+    "wof:lastmodified":1695886811,
     "wof:name":"Nevesinje",
     "wof:parent_id":85632267,
     "wof:placetype":"county",

--- a/data/110/875/918/1/1108759181.geojson
+++ b/data/110/875/918/1/1108759181.geojson
@@ -67,7 +67,7 @@
         }
     ],
     "wof:id":1108759181,
-    "wof:lastmodified":1694497961,
+    "wof:lastmodified":1695886168,
     "wof:name":"Novi Grad Sarajevo",
     "wof:parent_id":85669235,
     "wof:placetype":"county",

--- a/data/110/875/918/3/1108759183.geojson
+++ b/data/110/875/918/3/1108759183.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.027907,
-    "geom:area_square_m":247812802.219155,
+    "geom:area_square_m":247812802.219164,
     "geom:bbox":"17.5498704292,43.964870499,17.7912808859,44.2039080688",
     "geom:latitude":44.099267,
     "geom:longitude":17.669431,
@@ -117,9 +117,10 @@
     "wof:concordances":{
         "hasc:id":"BA.ZE.NT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323891,
-    "wof:geomhash":"aec2484a7831ca6f4c83919cdf876137",
+    "wof:geomhash":"7e453a86b39edd24b4674ee4d7d8e10c",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":1108759183,
-    "wof:lastmodified":1566605104,
+    "wof:lastmodified":1695886810,
     "wof:name":"Novi Travnik",
     "wof:parent_id":85669213,
     "wof:placetype":"county",

--- a/data/110/875/918/7/1108759187.geojson
+++ b/data/110/875/918/7/1108759187.geojson
@@ -109,7 +109,7 @@
         }
     ],
     "wof:id":1108759187,
-    "wof:lastmodified":1694497832,
+    "wof:lastmodified":1695886810,
     "wof:name":"Novo Sarajevo",
     "wof:parent_id":85669235,
     "wof:placetype":"county",

--- a/data/110/875/918/9/1108759189.geojson
+++ b/data/110/875/918/9/1108759189.geojson
@@ -67,7 +67,7 @@
         }
     ],
     "wof:id":1108759189,
-    "wof:lastmodified":1694497961,
+    "wof:lastmodified":1695886169,
     "wof:name":"Novo Sarajevo / Srpsko Novo Sarajevo",
     "wof:parent_id":85632267,
     "wof:placetype":"county",

--- a/data/110/875/919/1/1108759191.geojson
+++ b/data/110/875/919/1/1108759191.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.019533,
-    "geom:area_square_m":170573614.717946,
+    "geom:area_square_m":170573620.934207,
     "geom:bbox":"18.201455,45.004377,18.469659,45.139258",
     "geom:latitude":45.072545,
     "geom:longitude":18.32474,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"BA.DO.OD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323897,
-    "wof:geomhash":"d7ac7870f90413b67d9aaec9bc8d7705",
+    "wof:geomhash":"9c7fbfe463002de32184e0406b3a08b4",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108759191,
-    "wof:lastmodified":1627521590,
+    "wof:lastmodified":1695886169,
     "wof:name":"Odzak",
     "wof:parent_id":85669243,
     "wof:placetype":"county",

--- a/data/110/875/919/3/1108759193.geojson
+++ b/data/110/875/919/3/1108759193.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.044763,
-    "geom:area_square_m":396886513.403941,
+    "geom:area_square_m":396886513.404008,
     "geom:bbox":"18.3184505389,44.0506102195,18.832339231,44.3276244602",
     "geom:latitude":44.188807,
     "geom:longitude":18.559624,
@@ -114,9 +114,10 @@
     "wof:concordances":{
         "hasc:id":"BA.SA.OL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323899,
-    "wof:geomhash":"64d45b13b44144726c4082d512b0f444",
+    "wof:geomhash":"42f3649e483774fa854d673bb4a8889b",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":1108759193,
-    "wof:lastmodified":1566605105,
+    "wof:lastmodified":1695886811,
     "wof:name":"Olovo",
     "wof:parent_id":85669231,
     "wof:placetype":"county",

--- a/data/110/875/919/5/1108759195.geojson
+++ b/data/110/875/919/5/1108759195.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012456,
-    "geom:area_square_m":108883114.197399,
+    "geom:area_square_m":108882939.693635,
     "geom:bbox":"18.575992,44.950059,18.796218,45.096126",
     "geom:latitude":45.015295,
     "geom:longitude":18.681467,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"BA.BR.OR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323901,
-    "wof:geomhash":"35b2cbd5e99cc8bc152b979f4cc7663e",
+    "wof:geomhash":"45b4ca0b6850ad601638f8ec34216d3b",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108759195,
-    "wof:lastmodified":1627521590,
+    "wof:lastmodified":1695886169,
     "wof:name":"Orasje",
     "wof:parent_id":85669243,
     "wof:placetype":"county",

--- a/data/110/875/919/7/1108759197.geojson
+++ b/data/110/875/919/7/1108759197.geojson
@@ -67,7 +67,7 @@
         }
     ],
     "wof:id":1108759197,
-    "wof:lastmodified":1694497961,
+    "wof:lastmodified":1695886169,
     "wof:name":"Orasje / Srpsko Orasje",
     "wof:parent_id":85632267,
     "wof:placetype":"county",

--- a/data/110/875/919/9/1108759199.geojson
+++ b/data/110/875/919/9/1108759199.geojson
@@ -70,7 +70,7 @@
         }
     ],
     "wof:id":1108759199,
-    "wof:lastmodified":1694639716,
+    "wof:lastmodified":1695886169,
     "wof:name":"Pale",
     "wof:parent_id":85669239,
     "wof:placetype":"county",

--- a/data/110/875/920/1/1108759201.geojson
+++ b/data/110/875/920/1/1108759201.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.053434,
-    "geom:area_square_m":476817328.194873,
+    "geom:area_square_m":476817321.059944,
     "geom:bbox":"18.474035,43.680361,18.866056,43.969975",
     "geom:latitude":43.808368,
     "geom:longitude":18.643704,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"BA.SA.PA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323907,
-    "wof:geomhash":"36d5a24a64b06d1aeea67d2508df4b61",
+    "wof:geomhash":"5118517ff2ef9078822b83dc8cdd571c",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108759201,
-    "wof:lastmodified":1627521590,
+    "wof:lastmodified":1695886169,
     "wof:name":"Pale (rs)",
     "wof:parent_id":85632267,
     "wof:placetype":"county",

--- a/data/110/875/920/5/1108759205.geojson
+++ b/data/110/875/920/5/1108759205.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.050264,
-    "geom:area_square_m":450659641.714911,
+    "geom:area_square_m":450659728.924704,
     "geom:bbox":"17.085607,43.406993,17.596904,43.658298",
     "geom:latitude":43.523921,
     "geom:longitude":17.372927,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"BA.MO.PO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323909,
-    "wof:geomhash":"5ff264bedf34cad8e30230a791b0d14e",
+    "wof:geomhash":"ba65d8bc7cdeb8b2ea4d6a1ad8e28250",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108759205,
-    "wof:lastmodified":1627521590,
+    "wof:lastmodified":1695886169,
     "wof:name":"Posusje",
     "wof:parent_id":85669217,
     "wof:placetype":"county",

--- a/data/110/875/920/7/1108759207.geojson
+++ b/data/110/875/920/7/1108759207.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.094887,
-    "geom:area_square_m":830384434.726619,
+    "geom:area_square_m":830384283.517151,
     "geom:bbox":"16.489927,44.806183,17.026402,45.092196",
     "geom:latitude":44.948924,
     "geom:longitude":16.768442,
@@ -210,9 +210,10 @@
     "wof:concordances":{
         "hasc:id":"BA.PR.PI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323910,
-    "wof:geomhash":"cfbaa7c62771aeb359198f5d53f6345d",
+    "wof:geomhash":"312219b2fab5378435facb723d5fb9c4",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -222,7 +223,7 @@
         }
     ],
     "wof:id":1108759207,
-    "wof:lastmodified":1636496558,
+    "wof:lastmodified":1695886723,
     "wof:name":"Prijedor",
     "wof:parent_id":85632267,
     "wof:placetype":"county",

--- a/data/110/875/920/9/1108759209.geojson
+++ b/data/110/875/920/9/1108759209.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.071723,
-    "geom:area_square_m":628604032.636987,
+    "geom:area_square_m":628604032.636963,
     "geom:bbox":"17.4309846027,44.6968639479,17.8070177516,45.0234007366",
     "geom:latitude":44.863649,
     "geom:longitude":17.641174,
@@ -99,9 +99,10 @@
     "wof:concordances":{
         "hasc:id":"BA.BL.PN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323912,
-    "wof:geomhash":"6d7841bd0d8f507815600aa0f9ea6f7f",
+    "wof:geomhash":"096cb1bb07aee155f598fac144497a05",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1108759209,
-    "wof:lastmodified":1566605102,
+    "wof:lastmodified":1695886810,
     "wof:name":"Prnjavor",
     "wof:parent_id":85632267,
     "wof:placetype":"county",

--- a/data/110/875/921/1/1108759211.geojson
+++ b/data/110/875/921/1/1108759211.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.052668,
-    "geom:area_square_m":470109587.599064,
+    "geom:area_square_m":470109727.135411,
     "geom:bbox":"17.382907,43.678765,17.792424,43.881893",
     "geom:latitude":43.792185,
     "geom:longitude":17.582943,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"BA.MO.PZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323914,
-    "wof:geomhash":"df21f285cf2d4a662cf3c12174a8a4db",
+    "wof:geomhash":"9391a317acba531a8ce8e56a688395cc",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108759211,
-    "wof:lastmodified":1627521590,
+    "wof:lastmodified":1695886169,
     "wof:name":"Prozor / Prozor-rama",
     "wof:parent_id":85669221,
     "wof:placetype":"county",

--- a/data/110/875/921/3/1108759213.geojson
+++ b/data/110/875/921/3/1108759213.geojson
@@ -67,7 +67,7 @@
         }
     ],
     "wof:id":1108759213,
-    "wof:lastmodified":1694497961,
+    "wof:lastmodified":1695886169,
     "wof:name":"Ravno",
     "wof:parent_id":85669221,
     "wof:placetype":"county",

--- a/data/110/875/921/5/1108759215.geojson
+++ b/data/110/875/921/5/1108759215.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.072817,
-    "geom:area_square_m":649404960.398513,
+    "geom:area_square_m":649404960.398532,
     "geom:bbox":"18.8251102696,43.6782115698,19.2228919537,44.0157000047",
     "geom:latitude":43.842473,
     "geom:longitude":19.053673,
@@ -135,9 +135,10 @@
     "wof:concordances":{
         "hasc:id":"BA.GO.RO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323918,
-    "wof:geomhash":"507a76513a5dcf98af3a4a0708bed736",
+    "wof:geomhash":"0d0e5b47bee14e29d4241a56458fc17b",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -147,7 +148,7 @@
         }
     ],
     "wof:id":1108759215,
-    "wof:lastmodified":1566605106,
+    "wof:lastmodified":1695886811,
     "wof:name":"Rogatica",
     "wof:parent_id":85632267,
     "wof:placetype":"county",

--- a/data/110/875/921/7/1108759217.geojson
+++ b/data/110/875/921/7/1108759217.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.038087,
-    "geom:area_square_m":340759276.897107,
+    "geom:area_square_m":340759276.897078,
     "geom:bbox":"19.1464929078,43.541813,19.520472,43.7306551265",
     "geom:latitude":43.650981,
     "geom:longitude":19.361731,
@@ -117,9 +117,10 @@
     "wof:concordances":{
         "hasc:id":"BA.GO.RU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323920,
-    "wof:geomhash":"6c0113e5cb06b49bca7df7bb3b084e32",
+    "wof:geomhash":"c24b23920cea0831e471887a07a3b407",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":1108759217,
-    "wof:lastmodified":1566605106,
+    "wof:lastmodified":1695886811,
     "wof:name":"Rudo",
     "wof:parent_id":85632267,
     "wof:placetype":"county",

--- a/data/110/875/921/9/1108759219.geojson
+++ b/data/110/875/921/9/1108759219.geojson
@@ -141,6 +141,7 @@
     "wof:concordances":{
         "hasc:id":"BA.PR.SM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323922,
     "wof:geomhash":"9df105cdaa96843f46f581f5ed43c044",
@@ -153,7 +154,7 @@
         }
     ],
     "wof:id":1108759219,
-    "wof:lastmodified":1694497832,
+    "wof:lastmodified":1695886811,
     "wof:name":"Sanski Most",
     "wof:parent_id":85669207,
     "wof:placetype":"county",

--- a/data/110/875/922/3/1108759223.geojson
+++ b/data/110/875/922/3/1108759223.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022844,
-    "geom:area_square_m":200422491.171022,
+    "geom:area_square_m":200422472.17983,
     "geom:bbox":"16.376144,44.63474,16.920143,44.906077",
     "geom:latitude":44.803251,
     "geom:longitude":16.682867,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"BA.PR.SM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323924,
-    "wof:geomhash":"ca37084b0f10bfd4bc04b7b897b5dfaf",
+    "wof:geomhash":"0cd7d94713a2765867427523e08cde20",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108759223,
-    "wof:lastmodified":1627521590,
+    "wof:lastmodified":1695886170,
     "wof:name":"Sanski Most / Srpski Sanski Most",
     "wof:parent_id":85632267,
     "wof:placetype":"county",

--- a/data/110/875/922/5/1108759225.geojson
+++ b/data/110/875/922/5/1108759225.geojson
@@ -106,7 +106,7 @@
         }
     ],
     "wof:id":1108759225,
-    "wof:lastmodified":1694497831,
+    "wof:lastmodified":1695886809,
     "wof:name":"Sapna",
     "wof:parent_id":85669225,
     "wof:placetype":"county",

--- a/data/110/875/922/7/1108759227.geojson
+++ b/data/110/875/922/7/1108759227.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.027715,
-    "geom:area_square_m":245264200.707571,
+    "geom:area_square_m":245264219.906103,
     "geom:bbox":"18.743787,44.221327,19.017262,44.38187",
     "geom:latitude":44.302029,
     "geom:longitude":18.867549,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"BA.TU.SE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323927,
-    "wof:geomhash":"19d4556885818f4c3c4dd819f01562c0",
+    "wof:geomhash":"c99dcfe105aed5c128c5852fda571325",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108759227,
-    "wof:lastmodified":1627521590,
+    "wof:lastmodified":1695886170,
     "wof:name":"Sekovici",
     "wof:parent_id":85632267,
     "wof:placetype":"county",

--- a/data/110/875/922/9/1108759229.geojson
+++ b/data/110/875/922/9/1108759229.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.061413,
-    "geom:area_square_m":544350028.511356,
+    "geom:area_square_m":544349949.081361,
     "geom:bbox":"16.9068,44.080582,17.300309,44.366148",
     "geom:latitude":44.206093,
     "geom:longitude":17.123904,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"BA.JJ.SI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323929,
-    "wof:geomhash":"ed5ef37480a1e445b3b3d15b005b9ab8",
+    "wof:geomhash":"0493ed0b0c9913bdc261ea3c21ea329f",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108759229,
-    "wof:lastmodified":1627521591,
+    "wof:lastmodified":1695886170,
     "wof:name":"Sipovo",
     "wof:parent_id":85632267,
     "wof:placetype":"county",

--- a/data/110/875/923/1/1108759231.geojson
+++ b/data/110/875/923/1/1108759231.geojson
@@ -67,7 +67,7 @@
         }
     ],
     "wof:id":1108759231,
-    "wof:lastmodified":1694497961,
+    "wof:lastmodified":1695886170,
     "wof:name":"Siroki Brijeg",
     "wof:parent_id":85669217,
     "wof:placetype":"county",

--- a/data/110/875/923/3/1108759233.geojson
+++ b/data/110/875/923/3/1108759233.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.034638,
-    "geom:area_square_m":305555573.200333,
+    "geom:area_square_m":305555630.430551,
     "geom:bbox":"17.21836,44.350274,17.605008,44.647945",
     "geom:latitude":44.486987,
     "geom:longitude":17.376623,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"BA.BL.SV"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323933,
-    "wof:geomhash":"280076f8c240c76abae5b285cc561468",
+    "wof:geomhash":"857106da4f78bc4145591d15f4d4a517",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108759233,
-    "wof:lastmodified":1627521591,
+    "wof:lastmodified":1695886170,
     "wof:name":"Skender Vakuf / Knezevo",
     "wof:parent_id":85632267,
     "wof:placetype":"county",

--- a/data/110/875/923/5/1108759235.geojson
+++ b/data/110/875/923/5/1108759235.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.078926,
-    "geom:area_square_m":702393984.181227,
+    "geom:area_square_m":702394070.285757,
     "geom:bbox":"18.516653,43.826706,19.033552,44.124727",
     "geom:latitude":43.969331,
     "geom:longitude":18.777527,
@@ -123,9 +123,10 @@
     "wof:concordances":{
         "hasc:id":"BA.SA.SO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323935,
-    "wof:geomhash":"fe4024efd7d6fa8008461d440231345c",
+    "wof:geomhash":"414612f7c159c3549ac3d15c881fdd18",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":1108759235,
-    "wof:lastmodified":1627521591,
+    "wof:lastmodified":1695886170,
     "wof:name":"Sokolac",
     "wof:parent_id":85632267,
     "wof:placetype":"county",

--- a/data/110/875/923/7/1108759237.geojson
+++ b/data/110/875/923/7/1108759237.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.052272,
-    "geom:area_square_m":456712554.357774,
+    "geom:area_square_m":456712554.3578,
     "geom:bbox":"17.3835158714,44.9214040755,17.7924851023,45.13754",
     "geom:latitude":45.041096,
     "geom:longitude":17.569654,
@@ -126,9 +126,10 @@
     "wof:concordances":{
         "hasc:id":"BA.BL.SB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323937,
-    "wof:geomhash":"a61148ad7fcd38f0033b9225d1654dd7",
+    "wof:geomhash":"0e52b3dbe5f9e7a25fda20969102aa8c",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":1108759237,
-    "wof:lastmodified":1566605093,
+    "wof:lastmodified":1695886809,
     "wof:name":"Srbac",
     "wof:parent_id":85632267,
     "wof:placetype":"county",

--- a/data/110/875/924/1/1108759241.geojson
+++ b/data/110/875/924/1/1108759241.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.059629,
-    "geom:area_square_m":529894702.79075,
+    "geom:area_square_m":529894702.790736,
     "geom:bbox":"19.1538532691,43.9413066538,19.621463,44.1796695906",
     "geom:latitude":44.05505,
     "geom:longitude":19.346659,
@@ -219,9 +219,10 @@
     "wof:concordances":{
         "hasc:id":"BA.TU.SR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323938,
-    "wof:geomhash":"7e5bd66ad37906f7611cd44221e02ff2",
+    "wof:geomhash":"230a4c632e693a862d1c0e9c852cf12f",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -231,7 +232,7 @@
         }
     ],
     "wof:id":1108759241,
-    "wof:lastmodified":1566605093,
+    "wof:lastmodified":1695886809,
     "wof:name":"Srebrenica",
     "wof:parent_id":85632267,
     "wof:placetype":"county",

--- a/data/110/875/924/3/1108759243.geojson
+++ b/data/110/875/924/3/1108759243.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.028474,
-    "geom:area_square_m":250258075.24544,
+    "geom:area_square_m":250258075.245423,
     "geom:bbox":"18.3840833285,44.6073716798,18.655934279,44.7835872011",
     "geom:latitude":44.700411,
     "geom:longitude":18.524073,
@@ -129,9 +129,10 @@
     "wof:concordances":{
         "hasc:id":"BA.TU.SK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323940,
-    "wof:geomhash":"6bd7842c5d2c3d730dd9550d8f696d0b",
+    "wof:geomhash":"6355e9e5c62167ce814d9f6857f0a12c",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":1108759243,
-    "wof:lastmodified":1566605093,
+    "wof:lastmodified":1695886809,
     "wof:name":"Srebrenik",
     "wof:parent_id":85669225,
     "wof:placetype":"county",

--- a/data/110/875/924/5/1108759245.geojson
+++ b/data/110/875/924/5/1108759245.geojson
@@ -67,7 +67,7 @@
         }
     ],
     "wof:id":1108759245,
-    "wof:lastmodified":1694497961,
+    "wof:lastmodified":1695886170,
     "wof:name":"Stari Grad Sarajevo",
     "wof:parent_id":85669235,
     "wof:placetype":"county",

--- a/data/110/875/924/7/1108759247.geojson
+++ b/data/110/875/924/7/1108759247.geojson
@@ -67,7 +67,7 @@
         }
     ],
     "wof:id":1108759247,
-    "wof:lastmodified":1694497961,
+    "wof:lastmodified":1695886170,
     "wof:name":"Stari Grad Sarajevo/ Srpski Stari Grad",
     "wof:parent_id":85632267,
     "wof:placetype":"county",

--- a/data/110/875/924/9/1108759249.geojson
+++ b/data/110/875/924/9/1108759249.geojson
@@ -117,6 +117,7 @@
     "wof:concordances":{
         "hasc:id":"BA.MO.ST"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323946,
     "wof:geomhash":"76e9bc81b38742d00ed40e13e070c4a6",
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":1108759249,
-    "wof:lastmodified":1694497831,
+    "wof:lastmodified":1695886809,
     "wof:name":"Stolac",
     "wof:parent_id":85669221,
     "wof:placetype":"county",

--- a/data/110/875/925/1/1108759251.geojson
+++ b/data/110/875/925/1/1108759251.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.028691,
-    "geom:area_square_m":259015470.154259,
+    "geom:area_square_m":259015350.380976,
     "geom:bbox":"17.934447,43.002679,18.249039,43.197783",
     "geom:latitude":43.104883,
     "geom:longitude":18.066822,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"BA.MO.ST"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323948,
-    "wof:geomhash":"9a8a7ef9ee8cfc826f1cf816c5b65187",
+    "wof:geomhash":"d26cafe4fe5be2fcea7cd46a960e62d7",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108759251,
-    "wof:lastmodified":1627521591,
+    "wof:lastmodified":1695886171,
     "wof:name":"Stolac / Berkovici",
     "wof:parent_id":85632267,
     "wof:placetype":"county",

--- a/data/110/875/925/3/1108759253.geojson
+++ b/data/110/875/925/3/1108759253.geojson
@@ -67,7 +67,7 @@
         }
     ],
     "wof:id":1108759253,
-    "wof:lastmodified":1694497961,
+    "wof:lastmodified":1695886171,
     "wof:name":"Teocak",
     "wof:parent_id":85669225,
     "wof:placetype":"county",

--- a/data/110/875/925/5/1108759255.geojson
+++ b/data/110/875/925/5/1108759255.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01852,
-    "geom:area_square_m":162978722.994219,
+    "geom:area_square_m":162978722.120806,
     "geom:bbox":"17.8822,44.553874,18.09696,44.703664",
     "geom:latitude":44.627603,
     "geom:longitude":17.98287,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"BA.DO.TE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323951,
-    "wof:geomhash":"a42668f25406f026568a0edb67344525",
+    "wof:geomhash":"8c8a7eb56e1f5e33c8428ff6389c99ee",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108759255,
-    "wof:lastmodified":1627521591,
+    "wof:lastmodified":1695886171,
     "wof:name":"Tesanj",
     "wof:parent_id":85669231,
     "wof:placetype":"county",

--- a/data/110/875/925/9/1108759259.geojson
+++ b/data/110/875/925/9/1108759259.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.092082,
-    "geom:area_square_m":811136895.551175,
+    "geom:area_square_m":811136848.719259,
     "geom:bbox":"17.565976,44.378329,17.966148,44.751203",
     "geom:latitude":44.570387,
     "geom:longitude":17.758782,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"BA.DO.TS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323953,
-    "wof:geomhash":"363a5f474057fb6bda4fd12c1d281a1b",
+    "wof:geomhash":"6381d0ac2455b3f27997a16ec3b10e46",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108759259,
-    "wof:lastmodified":1627521591,
+    "wof:lastmodified":1695886171,
     "wof:name":"Teslic",
     "wof:parent_id":85632267,
     "wof:placetype":"county",

--- a/data/110/875/926/1/1108759261.geojson
+++ b/data/110/875/926/1/1108759261.geojson
@@ -133,7 +133,7 @@
         }
     ],
     "wof:id":1108759261,
-    "wof:lastmodified":1694497832,
+    "wof:lastmodified":1695886810,
     "wof:name":"Tomislavgrad",
     "wof:parent_id":85669203,
     "wof:placetype":"county",

--- a/data/110/875/926/3/1108759263.geojson
+++ b/data/110/875/926/3/1108759263.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.06245,
-    "geom:area_square_m":552869399.338574,
+    "geom:area_square_m":552869399.338571,
     "geom:bbox":"17.4265550579,44.1647528866,17.8380336405,44.3923997244",
     "geom:latitude":44.278075,
     "geom:longitude":17.629918,
@@ -195,9 +195,10 @@
     "wof:concordances":{
         "hasc:id":"BA.ZE.TV"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323957,
-    "wof:geomhash":"44be76c70bc3b9e16cf89295b5199d91",
+    "wof:geomhash":"84d18ab379d16ce2159f0fbee1581223",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -207,7 +208,7 @@
         }
     ],
     "wof:id":1108759263,
-    "wof:lastmodified":1566605104,
+    "wof:lastmodified":1695886810,
     "wof:name":"Travnik",
     "wof:parent_id":85669213,
     "wof:placetype":"county",

--- a/data/110/875/926/5/1108759265.geojson
+++ b/data/110/875/926/5/1108759265.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.096606,
-    "geom:area_square_m":877249542.201467,
+    "geom:area_square_m":877249322.181814,
     "geom:bbox":"17.951676,42.55653,18.576825,42.95941",
     "geom:latitude":42.745607,
     "geom:longitude":18.300283,
@@ -189,9 +189,10 @@
     "wof:concordances":{
         "hasc:id":"BA.MO.TB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323960,
-    "wof:geomhash":"50c43e77fabd53922aa88297e48ef0e3",
+    "wof:geomhash":"cd844b976d057103d9702353163efe12",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -201,7 +202,7 @@
         }
     ],
     "wof:id":1108759265,
-    "wof:lastmodified":1636496558,
+    "wof:lastmodified":1695886723,
     "wof:name":"Trebinje",
     "wof:parent_id":85632267,
     "wof:placetype":"county",

--- a/data/110/875/926/7/1108759267.geojson
+++ b/data/110/875/926/7/1108759267.geojson
@@ -60,6 +60,7 @@
     "wof:concordances":{
         "hasc:id":"BA.SA.TR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323962,
     "wof:geomhash":"e078236a0b3acaeb6b7e17d980da2743",
@@ -72,7 +73,7 @@
         }
     ],
     "wof:id":1108759267,
-    "wof:lastmodified":1694639716,
+    "wof:lastmodified":1695886171,
     "wof:name":"Trnovo",
     "wof:parent_id":85669235,
     "wof:placetype":"county",

--- a/data/110/875/926/9/1108759269.geojson
+++ b/data/110/875/926/9/1108759269.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013363,
-    "geom:area_square_m":119473397.134169,
+    "geom:area_square_m":119473424.469745,
     "geom:bbox":"18.374836,43.588249,18.574212,43.781213",
     "geom:latitude":43.69219,
     "geom:longitude":18.456412,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"BA.SA.TR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323964,
-    "wof:geomhash":"73a04e06390ccac430429b329d10f11b",
+    "wof:geomhash":"ab29b027c5db7130f9de671f40f1d17f",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108759269,
-    "wof:lastmodified":1627521592,
+    "wof:lastmodified":1695886171,
     "wof:name":"Trnovo (rs)",
     "wof:parent_id":85632267,
     "wof:placetype":"county",

--- a/data/110/875/927/1/1108759271.geojson
+++ b/data/110/875/927/1/1108759271.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.033528,
-    "geom:area_square_m":295404996.024564,
+    "geom:area_square_m":295404996.024575,
     "geom:bbox":"18.5542137223,44.4687077558,18.8661687616,44.6611757713",
     "geom:latitude":44.558598,
     "geom:longitude":18.68183,
@@ -240,9 +240,10 @@
     "wof:concordances":{
         "hasc:id":"BA.TU.TU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323966,
-    "wof:geomhash":"88b880f728795872b87b34eb1d154cad",
+    "wof:geomhash":"eb44bd35bb58dd9cf080a0407f89c7b1",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -252,7 +253,7 @@
         }
     ],
     "wof:id":1108759271,
-    "wof:lastmodified":1566605103,
+    "wof:lastmodified":1695886810,
     "wof:name":"Tuzla",
     "wof:parent_id":85669225,
     "wof:placetype":"county",

--- a/data/110/875/927/3/1108759273.geojson
+++ b/data/110/875/927/3/1108759273.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.019988,
-    "geom:area_square_m":175763747.907606,
+    "geom:area_square_m":175763747.90761,
     "geom:bbox":"18.9122678609,44.5838051103,19.1362193727,44.7726885842",
     "geom:latitude":44.672271,
     "geom:longitude":19.015123,
@@ -114,9 +114,10 @@
     "wof:concordances":{
         "hasc:id":"BA.BR.UG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323968,
-    "wof:geomhash":"aac91ab77974be864142cf40ec56602f",
+    "wof:geomhash":"b88ed569d13d6008c80c8fd26718f690",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":1108759273,
-    "wof:lastmodified":1566605103,
+    "wof:lastmodified":1695886810,
     "wof:name":"Ugljevik",
     "wof:parent_id":85632267,
     "wof:placetype":"county",

--- a/data/110/875/927/7/1108759277.geojson
+++ b/data/110/875/927/7/1108759277.geojson
@@ -78,6 +78,7 @@
     "wof:concordances":{
         "hasc:id":"BA.SA.VA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323969,
     "wof:geomhash":"6727bee71b5a81d883eb85b5d89e68dd",
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1108759277,
-    "wof:lastmodified":1694497832,
+    "wof:lastmodified":1695886810,
     "wof:name":"Usora",
     "wof:parent_id":85669231,
     "wof:placetype":"county",

--- a/data/110/875/927/9/1108759279.geojson
+++ b/data/110/875/927/9/1108759279.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.044489,
-    "geom:area_square_m":394680917.13563,
+    "geom:area_square_m":394680874.950036,
     "geom:bbox":"18.222163,44.034768,18.527418,44.293482",
     "geom:latitude":44.15581,
     "geom:longitude":18.360192,
@@ -87,9 +87,10 @@
     "wof:concordances":{
         "hasc:id":"BA.SA.VA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323971,
-    "wof:geomhash":"4d93fedf260260aa253ed95d8d1c0204",
+    "wof:geomhash":"329213946fae749c1fefe9516a18342b",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":1108759279,
-    "wof:lastmodified":1627521592,
+    "wof:lastmodified":1695886171,
     "wof:name":"Vares",
     "wof:parent_id":85669231,
     "wof:placetype":"county",

--- a/data/110/875/928/1/1108759281.geojson
+++ b/data/110/875/928/1/1108759281.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.038945,
-    "geom:area_square_m":339665377.518441,
+    "geom:area_square_m":339665467.79067,
     "geom:bbox":"15.764934,45.055064,16.129528,45.230189",
     "geom:latitude":45.143521,
     "geom:longitude":15.914939,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"BA.BH.VK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323973,
-    "wof:geomhash":"6ac94bf56efbeda49ae0f78e7b6bb059",
+    "wof:geomhash":"f02a8bac172fb22deebc90909b1389ff",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108759281,
-    "wof:lastmodified":1627521592,
+    "wof:lastmodified":1695886171,
     "wof:name":"Velika Kladusa",
     "wof:parent_id":85669207,
     "wof:placetype":"county",

--- a/data/110/875/928/3/1108759283.geojson
+++ b/data/110/875/928/3/1108759283.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.04693,
-    "geom:area_square_m":418878244.226405,
+    "geom:area_square_m":418878244.226345,
     "geom:bbox":"19.1209506932,43.682665575,19.5028553254,43.9536391512",
     "geom:latitude":43.794308,
     "geom:longitude":19.289717,
@@ -114,9 +114,10 @@
     "wof:concordances":{
         "hasc:id":"BA.GO.VG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323975,
-    "wof:geomhash":"c53343c2ee382e11b1e66fa63bfa1dae",
+    "wof:geomhash":"ac98dc83211143a7482cb884ab3016da",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":1108759283,
-    "wof:lastmodified":1566605108,
+    "wof:lastmodified":1695886811,
     "wof:name":"Visegrad",
     "wof:parent_id":85632267,
     "wof:placetype":"county",

--- a/data/110/875/928/5/1108759285.geojson
+++ b/data/110/875/928/5/1108759285.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.026291,
-    "geom:area_square_m":233815749.47174,
+    "geom:area_square_m":233815749.471772,
     "geom:bbox":"17.9926669543,43.9030350207,18.2637521738,44.103449934",
     "geom:latitude":44.008397,
     "geom:longitude":18.154605,
@@ -192,9 +192,10 @@
     "wof:concordances":{
         "hasc:id":"BA.SA.VS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323977,
-    "wof:geomhash":"c888779023e391e999b8fa7b89a186cb",
+    "wof:geomhash":"47d088d858a17fe0c8fcb6569375ab22",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -204,7 +205,7 @@
         }
     ],
     "wof:id":1108759285,
-    "wof:lastmodified":1566605108,
+    "wof:lastmodified":1695886811,
     "wof:name":"Visoko",
     "wof:parent_id":85669231,
     "wof:placetype":"county",

--- a/data/110/875/928/7/1108759287.geojson
+++ b/data/110/875/928/7/1108759287.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017622,
-    "geom:area_square_m":156406448.858711,
+    "geom:area_square_m":156406448.858705,
     "geom:bbox":"17.702667438,44.0402378866,17.8789419561,44.2125240483",
     "geom:latitude":44.129106,
     "geom:longitude":17.781416,
@@ -117,9 +117,10 @@
     "wof:concordances":{
         "hasc:id":"BA.ZE.VT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323979,
-    "wof:geomhash":"ce34d4b012010f41b111670f5931ade0",
+    "wof:geomhash":"a652d1c5587dfa15074f25d737ff0c59",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":1108759287,
-    "wof:lastmodified":1566605108,
+    "wof:lastmodified":1695886811,
     "wof:name":"Vitez",
     "wof:parent_id":85669213,
     "wof:placetype":"county",

--- a/data/110/875/928/9/1108759289.geojson
+++ b/data/110/875/928/9/1108759289.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.031683,
-    "geom:area_square_m":280786509.34287,
+    "geom:area_square_m":280786366.754558,
     "geom:bbox":"18.815355,44.122451,19.114253,44.308898",
     "geom:latitude":44.215355,
     "geom:longitude":18.97568,
@@ -141,9 +141,10 @@
     "wof:concordances":{
         "hasc:id":"BA.TU.VL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323981,
-    "wof:geomhash":"3f69f4855780c3738ca88ac3f6ffeb73",
+    "wof:geomhash":"13e677bbd455ce5e21adbc5fd8648eda",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -153,7 +154,7 @@
         }
     ],
     "wof:id":1108759289,
-    "wof:lastmodified":1636496558,
+    "wof:lastmodified":1695886723,
     "wof:name":"Vlasenica",
     "wof:parent_id":85632267,
     "wof:placetype":"county",

--- a/data/110/875/929/1/1108759291.geojson
+++ b/data/110/875/929/1/1108759291.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008094,
-    "geom:area_square_m":72080710.235947,
+    "geom:area_square_m":72080576.324345,
     "geom:bbox":"18.29576,43.871745,18.452079,43.981086",
     "geom:latitude":43.925699,
     "geom:longitude":18.363548,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"BA.SA.VO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323983,
-    "wof:geomhash":"b366a11b5c18d7131713943a045cc3f9",
+    "wof:geomhash":"c81303025b383d250ea2d92b29fd5ebc",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108759291,
-    "wof:lastmodified":1627521592,
+    "wof:lastmodified":1695886172,
     "wof:name":"Vogosca",
     "wof:parent_id":85669235,
     "wof:placetype":"county",

--- a/data/110/875/929/5/1108759295.geojson
+++ b/data/110/875/929/5/1108759295.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.066536,
-    "geom:area_square_m":588056679.586748,
+    "geom:area_square_m":588056747.932135,
     "geom:bbox":"18.064045,44.255505,18.492068,44.516342",
     "geom:latitude":44.376108,
     "geom:longitude":18.247276,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"BA.ZE.ZA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323985,
-    "wof:geomhash":"40f5e3a9767714cacb23358babfbf931",
+    "wof:geomhash":"06dedf782ce3f5c2b20bdf1d890d6558",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108759295,
-    "wof:lastmodified":1627521592,
+    "wof:lastmodified":1695886172,
     "wof:name":"Zavidovici",
     "wof:parent_id":85669231,
     "wof:placetype":"county",

--- a/data/110/875/929/7/1108759297.geojson
+++ b/data/110/875/929/7/1108759297.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.064175,
-    "geom:area_square_m":568140391.863044,
+    "geom:area_square_m":568140391.863105,
     "geom:bbox":"17.7406764055,44.097958039,18.0959513211,44.4596086076",
     "geom:latitude":44.27842,
     "geom:longitude":17.926644,
@@ -234,9 +234,10 @@
     "wof:concordances":{
         "hasc:id":"BA.ZE.ZN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323987,
-    "wof:geomhash":"e479feaec7c9931d675c8f7dbf541c2c",
+    "wof:geomhash":"0e1924d01374b287d302f2c0ac367be7",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -246,7 +247,7 @@
         }
     ],
     "wof:id":1108759297,
-    "wof:lastmodified":1566605101,
+    "wof:lastmodified":1695886810,
     "wof:name":"Zenica",
     "wof:parent_id":85669231,
     "wof:placetype":"county",

--- a/data/110/875/929/9/1108759299.geojson
+++ b/data/110/875/929/9/1108759299.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.02313,
-    "geom:area_square_m":204304514.224826,
+    "geom:area_square_m":204304572.089299,
     "geom:bbox":"17.894314,44.322654,18.128653,44.48677",
     "geom:latitude":44.411487,
     "geom:longitude":18.009329,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"BA.ZE.ZP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323989,
-    "wof:geomhash":"f319a005893968bf82afd273d552815a",
+    "wof:geomhash":"f798542a1aba3a173a16b6b13c39e163",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108759299,
-    "wof:lastmodified":1627521592,
+    "wof:lastmodified":1695886172,
     "wof:name":"Zepce",
     "wof:parent_id":85669231,
     "wof:placetype":"county",

--- a/data/110/875/930/1/1108759301.geojson
+++ b/data/110/875/930/1/1108759301.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.032778,
-    "geom:area_square_m":289500316.65946,
+    "geom:area_square_m":289500280.915898,
     "geom:bbox":"18.51643,44.319706,18.829608,44.507571",
     "geom:latitude":44.416603,
     "geom:longitude":18.66496,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"BA.TU.ZI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323990,
-    "wof:geomhash":"f7027ea199c6430f0c051128f3b394b8",
+    "wof:geomhash":"fe954f80d55317826e9a50cbefc6c983",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108759301,
-    "wof:lastmodified":1627521592,
+    "wof:lastmodified":1695886172,
     "wof:name":"Zivinice",
     "wof:parent_id":85669225,
     "wof:placetype":"county",

--- a/data/110/875/930/3/1108759303.geojson
+++ b/data/110/875/930/3/1108759303.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.043766,
-    "geom:area_square_m":386376217.935925,
+    "geom:area_square_m":386376217.935951,
     "geom:bbox":"18.9625983695,44.2626637949,19.2257080909,44.6145702525",
     "geom:latitude":44.442397,
     "geom:longitude":19.082663,
@@ -168,9 +168,10 @@
     "wof:concordances":{
         "hasc:id":"BA.TU.ZV"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BA",
     "wof:created":1481323992,
-    "wof:geomhash":"035e39a1c3b7f91b891946139cf1a631",
+    "wof:geomhash":"348588297c8279bd5c58f6c863e95e06",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -180,7 +181,7 @@
         }
     ],
     "wof:id":1108759303,
-    "wof:lastmodified":1566605090,
+    "wof:lastmodified":1695886808,
     "wof:name":"Zvornik",
     "wof:parent_id":85632267,
     "wof:placetype":"county",

--- a/data/856/322/67/85632267.geojson
+++ b/data/856/322/67/85632267.geojson
@@ -23,7 +23,7 @@
     "mps:latitude":44.016198,
     "mps:longitude":18.984404,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":9.0,
     "name:eng_x_colloquial":[
@@ -134,8 +134,10 @@
         85632609
     ],
     "wof:concordances":{
+        "iso:code":"BA-SRP",
         "qs_pg:id":224784
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BA",
     "wof:geom_alt":[
         "quattroshapes"
@@ -159,7 +161,7 @@
         "srp",
         "hrv"
     ],
-    "wof:lastmodified":1694493125,
+    "wof:lastmodified":1695884281,
     "wof:name":"Republic of Srpska",
     "wof:parent_id":85632609,
     "wof:placetype":"region",

--- a/data/856/322/79/85632279.geojson
+++ b/data/856/322/79/85632279.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.055005,
-    "geom:area_square_m":482404976.073897,
+    "geom:area_square_m":482405004.809258,
     "geom:bbox":"18.5191,44.722381,19.006743,44.965867",
     "geom:latitude":44.824327,
     "geom:longitude":18.736414,
@@ -373,15 +373,17 @@
     "wof:concordances":{
         "fips:code":"BK03",
         "hasc:id":"BA.BR",
+        "iso:code":"BA-BRC",
         "iso:id":"BA-BRC",
         "qs_pg:id":224784,
         "wd:id":"Q194483"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BA",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d29cc2cf5ee8c7ecc5a19633e87a31ab",
+    "wof:geomhash":"6a051bc651e8c9a8c788a41a7bb11f33",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -400,7 +402,7 @@
         "srp",
         "hrv"
     ],
-    "wof:lastmodified":1690855782,
+    "wof:lastmodified":1695884355,
     "wof:name":"Brcko Distrikt",
     "wof:parent_id":85632609,
     "wof:placetype":"region",

--- a/data/856/326/09/85632609.geojson
+++ b/data/856/326/09/85632609.geojson
@@ -1423,6 +1423,7 @@
         "hasc:id":"BA",
         "icao:code":"T9",
         "ioc:id":"BIH",
+        "iso:code":"BA",
         "itu:id":"BIH",
         "m49:code":"070",
         "marc:id":"bn",
@@ -1436,6 +1437,7 @@
         "wk:page":"Bosnia and Herzegovina",
         "wmo:id":"BG"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BA",
     "wof:country_alpha3":"BIH",
     "wof:geom_alt":[
@@ -1462,7 +1464,7 @@
         "srp",
         "hrv"
     ],
-    "wof:lastmodified":1694639517,
+    "wof:lastmodified":1695881173,
     "wof:name":"Bosnia and Herzegovina",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/856/692/03/85669203.geojson
+++ b/data/856/692/03/85669203.geojson
@@ -233,10 +233,12 @@
         "gn:id":3343740,
         "gp:id":24551287,
         "hasc:id":"BA.BF",
+        "iso:code_pseudo":"BA-BIH-WB",
         "qs_pg:id":219962,
         "wd:id":"Q18277",
         "wk:page":"Canton 10"
     },
+    "wof:concordances_official":"iso:code_pseudo",
     "wof:country":"BA",
     "wof:geom_alt":[
         "quattroshapes"
@@ -260,7 +262,7 @@
         "srp",
         "hrv"
     ],
-    "wof:lastmodified":1694493256,
+    "wof:lastmodified":1695884840,
     "wof:name":"West Bosnia",
     "wof:parent_id":85632609,
     "wof:placetype":"region",

--- a/data/856/692/07/85669207.geojson
+++ b/data/856/692/07/85669207.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.480088,
-    "geom:area_square_m":4214414386.884384,
+    "geom:area_square_m":4214414165.513814,
     "geom:bbox":"15.72972,44.242032,16.904204,45.230189",
     "geom:latitude":44.770419,
     "geom:longitude":16.23862,
@@ -327,17 +327,19 @@
         "gn:id":3343704,
         "gp:id":24551286,
         "hasc:id":"HR.ZD",
+        "iso:code":"HR-13",
         "iso:id":"HR-13",
         "qs_pg:id":212437,
         "unlc:id":"BA-01",
         "wd:id":"Q18248",
         "wk:page":"Una-Sana Canton"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BA",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"74895da17fba35afdad0399435fed4f9",
+    "wof:geomhash":"834c4db3017d77d7e035874dc253ce25",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -356,7 +358,7 @@
         "srp",
         "hrv"
     ],
-    "wof:lastmodified":1690855780,
+    "wof:lastmodified":1695884841,
     "wof:name":"Una-Sana",
     "wof:parent_id":85632609,
     "wof:placetype":"region",

--- a/data/856/692/13/85669213.geojson
+++ b/data/856/692/13/85669213.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.361269,
-    "geom:area_square_m":3207529853.534083,
+    "geom:area_square_m":3207529706.834018,
     "geom:bbox":"17.205138,43.79807,18.184152,44.45506",
     "geom:latitude":44.108209,
     "geom:longitude":17.636944,
@@ -346,15 +346,17 @@
         "gn:id":3343731,
         "gp:id":24551285,
         "hasc:id":"BA.BF",
+        "iso:code":"BA-BIH",
         "iso:id":"BA-BIH",
         "qs_pg:id":1154620,
         "wd:id":"Q18262"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BA",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6555f93ffe7cc4abb15946afc3d3d2cb",
+    "wof:geomhash":"0bc9090c52d40bc7f90a4c90b5d7b9b0",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -373,7 +375,7 @@
         "srp",
         "hrv"
     ],
-    "wof:lastmodified":1690855781,
+    "wof:lastmodified":1695884841,
     "wof:name":"Central Bosnia",
     "wof:parent_id":85632609,
     "wof:placetype":"region",

--- a/data/856/692/17/85669217.geojson
+++ b/data/856/692/17/85669217.geojson
@@ -335,10 +335,12 @@
         "gn:id":3343736,
         "gp:id":24551283,
         "hasc:id":"BA.BF",
+        "iso:code_pseudo":"BA-BIH-WH",
         "qs_pg:id":1193489,
         "wd:id":"Q18275",
         "wk:page":"West Herzegovina Canton"
     },
+    "wof:concordances_official":"iso:code_pseudo",
     "wof:country":"BA",
     "wof:geom_alt":[
         "quattroshapes"
@@ -362,7 +364,7 @@
         "srp",
         "hrv"
     ],
-    "wof:lastmodified":1694493256,
+    "wof:lastmodified":1695884840,
     "wof:name":"West Herzegovina",
     "wof:parent_id":85632609,
     "wof:placetype":"region",

--- a/data/856/692/21/85669221.geojson
+++ b/data/856/692/21/85669221.geojson
@@ -334,11 +334,13 @@
         "gn:id":3343733,
         "gp:id":24551284,
         "hasc:id":"BA.BF",
+        "iso:code":"BA-07",
         "qs_pg:id":212436,
         "unlc:id":"BA-07",
         "wd:id":"Q18273",
         "wk:page":"Herzegovina-Neretva Canton"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BA",
     "wof:geom_alt":[
         "quattroshapes"
@@ -362,7 +364,7 @@
         "srp",
         "hrv"
     ],
-    "wof:lastmodified":1694493257,
+    "wof:lastmodified":1695884840,
     "wof:name":"Herzegovina-Neretva",
     "wof:parent_id":85632609,
     "wof:placetype":"region",

--- a/data/856/692/25/85669225.geojson
+++ b/data/856/692/25/85669225.geojson
@@ -302,11 +302,13 @@
         "gn:id":3343716,
         "gp:id":24551278,
         "hasc:id":"BA.BF",
+        "iso:code":"BA-03",
         "qs_pg:id":1287915,
         "unlc:id":"BA-03",
         "wd:id":"Q18250",
         "wk:page":"Tuzla Canton"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BA",
     "wof:geom_alt":[
         "quattroshapes"
@@ -330,7 +332,7 @@
         "srp",
         "hrv"
     ],
-    "wof:lastmodified":1694493257,
+    "wof:lastmodified":1695884841,
     "wof:name":"Tuzla",
     "wof:parent_id":85632609,
     "wof:placetype":"region",

--- a/data/856/692/31/85669231.geojson
+++ b/data/856/692/31/85669231.geojson
@@ -327,11 +327,13 @@
         "gn:id":3343722,
         "gp:id":24551279,
         "hasc:id":"BA.BF",
+        "iso:code":"BA-04",
         "qs_pg:id":1287916,
         "unlc:id":"BA-04",
         "wd:id":"Q18253",
         "wk:page":"Zenica-Doboj Canton"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BA",
     "wof:geom_alt":[
         "quattroshapes"
@@ -355,7 +357,7 @@
         "srp",
         "hrv"
     ],
-    "wof:lastmodified":1694493257,
+    "wof:lastmodified":1695884841,
     "wof:name":"Zenica-Doboj",
     "wof:parent_id":85632609,
     "wof:placetype":"region",

--- a/data/856/692/35/85669235.geojson
+++ b/data/856/692/35/85669235.geojson
@@ -291,11 +291,13 @@
         "gn:id":3343737,
         "gp:id":29389657,
         "hasc:id":"BA.BF",
+        "iso:code":"BA-09",
         "qs_pg:id":1086560,
         "unlc:id":"BA-09",
         "wd:id":"Q18276",
         "wk:page":"Sarajevo Canton"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BA",
     "wof:geom_alt":[
         "quattroshapes"
@@ -319,7 +321,7 @@
         "srp",
         "hrv"
     ],
-    "wof:lastmodified":1694493257,
+    "wof:lastmodified":1695884841,
     "wof:name":"Sarajevo",
     "wof:parent_id":85632609,
     "wof:placetype":"region",

--- a/data/856/692/39/85669239.geojson
+++ b/data/856/692/39/85669239.geojson
@@ -316,11 +316,13 @@
         "gn:id":3343726,
         "gp:id":24551280,
         "hasc:id":"BA.BF",
+        "iso:code":"BA-05",
         "qs_pg:id":1193490,
         "unlc:id":"BA-05",
         "wd:id":"Q18256",
         "wk:page":"Bosnian-Podrinje Canton Gora\u017ede"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BA",
     "wof:geom_alt":[
         "quattroshapes"
@@ -344,7 +346,7 @@
         "srp",
         "hrv"
     ],
-    "wof:lastmodified":1694493257,
+    "wof:lastmodified":1695884841,
     "wof:name":"Bosnian Podrinje",
     "wof:parent_id":85632609,
     "wof:placetype":"region",

--- a/data/856/692/43/85669243.geojson
+++ b/data/856/692/43/85669243.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.035576,
-    "geom:area_square_m":310780486.905679,
+    "geom:area_square_m":310780391.886318,
     "geom:bbox":"18.201455,44.950059,18.796218,45.139258",
     "geom:latitude":45.051108,
     "geom:longitude":18.474503,
@@ -310,17 +310,19 @@
         "gn:id":3343706,
         "gp:id":24551282,
         "hasc:id":"BA.SR",
+        "iso:code":"BA-SRP",
         "iso:id":"BA-SRP",
         "qs_pg:id":1015365,
         "unlc:id":"BA-02",
         "wd:id":"Q18249",
         "wk:page":"Posavina Canton"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BA",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fb2ec5c43da6296bf8a6c1286e4e6bc0",
+    "wof:geomhash":"aea204893fa4a60bcf5768416cb507ca",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -339,7 +341,7 @@
         "srp",
         "hrv"
     ],
-    "wof:lastmodified":1690855780,
+    "wof:lastmodified":1695884841,
     "wof:name":"Posavina",
     "wof:parent_id":85632609,
     "wof:placetype":"region",

--- a/data/890/518/499/890518499.geojson
+++ b/data/890/518/499/890518499.geojson
@@ -147,7 +147,7 @@
         }
     ],
     "wof:id":890518499,
-    "wof:lastmodified":1694497769,
+    "wof:lastmodified":1695886971,
     "wof:name":"Modri\u010da",
     "wof:parent_id":85632267,
     "wof:placetype":"county",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.